### PR TITLE
Backport shared_tests from `master` branch

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/activation.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/activation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -39,7 +39,8 @@ static std::map<ngraph::helpers::ActivationTypes, std::string> activationNames =
         {ngraph::helpers::ActivationTypes::Exp,       "Exp"},
         {ngraph::helpers::ActivationTypes::Log,       "Log"},
         {ngraph::helpers::ActivationTypes::Sign,      "Sign"},
-        {ngraph::helpers::ActivationTypes::Abs,       "Abs"}
+        {ngraph::helpers::ActivationTypes::Abs,       "Abs"},
+        // {ngraph::helpers::ActivationTypes::Gelu,      "Gelu"}
 };
 
 typedef std::tuple<

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/add.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/add.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+namespace LayerTestsDefinitions {
+    typedef std::tuple<
+            InferenceEngine::Precision,         // Network precision
+            std::vector<std::vector<size_t>>,   // Input shapes
+            std::string,                        // Device name
+            std::map<std::string, std::string>  // Config
+            > addParams;
+
+class AddLayerTest : public testing::WithParamInterface<addParams>,
+                     public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<addParams> obj);
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/batch_to_space.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/batch_to_space.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,11 +18,11 @@ using batchToSpaceParamsTuple = typename std::tuple<
         std::vector<size_t>,               // crops begin
         std::vector<size_t>,               // crops end
         std::vector<size_t>,               // Input shapes
-        InferenceEngine::Precision,        // Input precision
         InferenceEngine::Precision,        // Network precision
         std::string>;                      // Device name>;
 
-class BatchToSpaceLayerTest : public LayerTestsUtils::LayerTestsCommonClass<batchToSpaceParamsTuple> {
+class BatchToSpaceLayerTest : public testing::WithParamInterface<batchToSpaceParamsTuple>,
+                              public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/concat.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/concat.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -16,14 +16,14 @@
 namespace LayerTestsDefinitions {
 
 using concatParamsTuple = typename std::tuple<
+        //TODO: according to specification axis have to be int, negative values are allowed
         size_t,                            // Concat axis
         std::vector<std::vector<size_t>>,  // Input shapes
-        InferenceEngine::Precision,        // Input precision
         InferenceEngine::Precision,        // Network precision
         std::string>;                      // Device name
 
-class ConcatLayerTest
-        : public LayerTestsUtils::LayerTestsCommonClass<concatParamsTuple> {
+class ConcatLayerTest : public testing::WithParamInterface<concatParamsTuple>,
+                        public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<concatParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution_backprop_data.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -21,20 +21,20 @@ typedef std::tuple<
         InferenceEngine::SizeVector,    // Dilation
         size_t,                         // Num out channels
         ngraph::op::PadType             // Padding type
-> convSpecificParams;
+> convBackpropDataSpecificParams;
 typedef std::tuple<
-        convSpecificParams,
+        convBackpropDataSpecificParams,
         InferenceEngine::Precision,     // Net precision
         InferenceEngine::SizeVector,    // Input shapes
         LayerTestsUtils::TargetDevice   // Device name
-> convLayerTestParamsSet;
+> convBackpropDataLayerTestParamsSet;
 namespace LayerTestsDefinitions {
 
 
-class ConvolutionLayerTest : public testing::WithParamInterface<convLayerTestParamsSet>,
-                             public LayerTestsUtils::LayerTestsCommon {
+class ConvolutionBackpropDataLayerTest : public testing::WithParamInterface<convBackpropDataLayerTestParamsSet>,
+                                         public LayerTestsUtils::LayerTestsCommon {
 public:
-    static std::string getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet> obj);
+    static std::string getTestCaseName(testing::TestParamInfo<convBackpropDataLayerTestParamsSet> obj);
 
 protected:
     void SetUp() override;

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/ctc_greedy_decoder.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/ctc_greedy_decoder.hpp
@@ -1,0 +1,53 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <tuple>
+#include <string>
+#include <map>
+#include <memory>
+#include <set>
+#include <functional>
+#include <gtest/gtest.h>
+
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+#include "details/ie_exception.hpp"
+
+#include "ngraph/opsets/opset1.hpp"
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+
+namespace LayerTestsDefinitions {
+typedef std::tuple<
+    InferenceEngine::Precision,
+    InferenceEngine::SizeVector,
+    bool,
+    std::string> ctcGreedyDecoderParams;
+
+class CTCGreedyDecoderLayerTest
+    :  public testing::WithParamInterface<ctcGreedyDecoderParams>,
+       public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<ctcGreedyDecoderParams>& obj);
+
+protected:
+    InferenceEngine::SizeVector inputShapes;
+    InferenceEngine::SizeVector sequenceLengths;
+    bool mergeRepeated;
+
+    std::vector<std::vector<std::uint8_t>> CalculateRefs() override;
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/cum_sum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/cum_sum.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+        InferenceEngine::SizeVector, // Input shapes
+        InferenceEngine::Precision,  // Input precision
+        int64_t,                     // Axis
+        bool,                        // Exclusive
+        bool,                        // Reverse
+        std::string> cumSumParams;   // Device name
+
+class CumSumLayerTest : public testing::WithParamInterface<cumSumParams>, public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<cumSumParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/eltwise.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/eltwise.hpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// NOTE: WILL BE REWORKED (31905)
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+#include "common_test_utils/common_layers_params.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/test_common.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "ie_core.hpp"
+
+namespace EltwiseTestNamespace {
+
+    using ParameterInputIdx = int;
+    enum class InputLayerType {
+        CONSTANT,
+        PARAMETER
+    };
+    enum class EltwiseOpType {
+        ADD,
+        SUBSTRACT,
+        MULTIPLY
+    };
+    const char* InputLayerType_to_string(InputLayerType lt);
+    const char* EltwiseOpType_to_string(EltwiseOpType eOp);
+}// namespace EltwiseTestNamespace
+
+typedef std::tuple<
+    EltwiseTestNamespace::EltwiseOpType,       // eltwise op type
+    EltwiseTestNamespace::ParameterInputIdx,   // primary input idx
+    EltwiseTestNamespace::InputLayerType,      // secondary input type
+    InferenceEngine::Precision,                // Net precision
+    InferenceEngine::SizeVector,               // Input shapes
+    std::string,                               // Device name
+    std::map<std::string, std::string>         // Additional network configuration
+> eltwiseLayerTestParamsSet;
+
+class EltwiseLayerTest : public testing::WithParamInterface<eltwiseLayerTestParamsSet>,
+    public LayerTestsUtils::LayerTestsCommon {
+protected:
+    void SetUp() override;
+
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<eltwiseLayerTestParamsSet> obj);
+};

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/equal.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/equal.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+
+namespace LayerTestsDefinitions {
+
+using EqualTestParam = typename std::tuple<
+        std::vector<InferenceEngine::SizeVector>,  // Input shapes
+        InferenceEngine::Precision,                // Input precision
+        InferenceEngine::Precision,                // Output precision
+        LayerTestsUtils::TargetDevice>;            // Config
+
+class EqualLayerTest : public testing::WithParamInterface<EqualTestParam>,
+                       public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<EqualTestParam>& obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/extract_image_patches.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/extract_image_patches.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+namespace LayerTestsDefinitions {
+
+using extractImagePatchesTuple = typename std::tuple<
+        std::vector<size_t>,               // input shape
+        std::vector<size_t>,               // kernel size
+        std::vector<size_t>,               // strides
+        std::vector<size_t>,               // rates
+        ngraph::op::PadType,               // pad type
+        InferenceEngine::Precision,        // Network precision
+        LayerTestsUtils::TargetDevice>;                      // Device name
+
+class ExtractImagePatchesTest : public testing::WithParamInterface<extractImagePatchesTuple>,
+                              public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/fake_quantize.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/fake_quantize.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+typedef std::tuple<
+        size_t,             // levels
+        std::vector<size_t> // const inputs shape
+> fqSpecificParams;
+typedef std::tuple<
+        fqSpecificParams,
+        InferenceEngine::Precision,   // Net precision
+        InferenceEngine::SizeVector,  // Input shapes
+        LayerTestsUtils::TargetDevice // Device name
+> fqLayerTestParamsSet;
+namespace LayerTestsDefinitions {
+
+
+class FakeQuantizeLayerTest : public testing::WithParamInterface<fqLayerTestParamsSet>,
+                              public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<fqLayerTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/greater.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/greater.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <map>
+#include <memory>
+
+namespace LayerTestsDefinitions {
+
+using GreaterTestParam = typename std::tuple<
+        std::vector<InferenceEngine::SizeVector>,  // Input shapes
+        InferenceEngine::Precision,                // Input precision
+        InferenceEngine::Precision,                // Output precision
+        LayerTestsUtils::TargetDevice>;            // Config
+
+class GreaterLayerTest : public testing::WithParamInterface<GreaterTestParam>,
+                         public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<GreaterTestParam>& obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/grn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/grn.hpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <tuple>
+#include <string>
+#include <map>
+#include <memory>
+#include <set>
+#include <functional>
+#include <gtest/gtest.h>
+
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+#include "details/ie_exception.hpp"
+
+#include "ngraph/opsets/opset1.hpp"
+#include "ngraph/runtime/reference/relu.hpp"
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+
+namespace LayerTestsDefinitions {
+typedef std::tuple<
+    InferenceEngine::Precision,
+    InferenceEngine::SizeVector,
+    float,
+    std::string> grnParams;
+
+class GrnLayerTest
+    : public testing::WithParamInterface<grnParams>,
+      public LayerTestsUtils::LayerTestsCommon{
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<grnParams>& obj);
+
+protected:
+    InferenceEngine::SizeVector inputShapes;
+    float bias;
+
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+typedef std::tuple<
+        InferenceEngine::SizeVector,
+        InferenceEngine::SizeVector,
+        std::vector<ptrdiff_t>,
+        std::vector<ptrdiff_t>,
+        InferenceEngine::SizeVector,
+        size_t,
+        size_t,
+        ngraph::op::PadType> groupConvSpecificParams;
+typedef std::tuple<
+        groupConvSpecificParams,
+        InferenceEngine::Precision,
+        InferenceEngine::SizeVector,
+        LayerTestsUtils::TargetDevice> groupConvLayerTestParamsSet;
+
+namespace LayerTestsDefinitions {
+
+class GroupConvolutionLayerTest : public testing::WithParamInterface<groupConvLayerTestParamsSet>,
+                                  public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution_backprop_data.hpp
@@ -1,0 +1,42 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+typedef std::tuple<
+        InferenceEngine::SizeVector,
+        InferenceEngine::SizeVector,
+        std::vector<ptrdiff_t>,
+        std::vector<ptrdiff_t>,
+        InferenceEngine::SizeVector,
+        size_t,
+        size_t,
+        ngraph::op::PadType> groupConvBackpropDataSpecificParams;
+typedef std::tuple<
+        groupConvBackpropDataSpecificParams,
+        InferenceEngine::Precision,
+        InferenceEngine::SizeVector,
+        LayerTestsUtils::TargetDevice> groupConvBackpropDataLayerTestParamsSet;
+
+namespace LayerTestsDefinitions {
+
+class GroupConvBackpropDataLayerTest : public testing::WithParamInterface<groupConvBackpropDataLayerTestParamsSet>,
+                                       public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<groupConvBackpropDataLayerTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/lrn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/lrn.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+        double,                        // Alpha
+        size_t,                        // Beta
+        size_t,                        // Bias
+        size_t,                        // Size,
+        InferenceEngine::Precision,    // Network precision
+        InferenceEngine::SizeVector,   // Input shapes
+        std::string                    // Device name
+> lrnLayerTestParamsSet;
+
+class LrnLayerTest
+        : public testing::WithParamInterface<lrnLayerTestParamsSet>,
+          public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<lrnLayerTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/maximum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/maximum.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace LayerTestsDefinitions {
+
+using MaximumParamsTuple = typename std::tuple<
+        std::vector<std::vector<size_t>>, //input shapes
+        InferenceEngine::Precision,       //Network precision
+        std::string>;                     //Device name
+
+class MaximumLayerTest:
+        public testing::WithParamInterface<MaximumParamsTuple>,
+        public LayerTestsUtils::LayerTestsCommon{
+public:
+    std::shared_ptr<ngraph::Function> fn;
+    static std::string getTestCaseName(const testing::TestParamInfo<MaximumParamsTuple>& obj);
+protected:
+    void SetUp() override;
+};
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/multiply.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/multiply.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "common_test_utils/test_constants.hpp"
+
+namespace LayerTestsDefinitions {
+
+using MultiplyParamsTuple = typename std::tuple<
+        std::vector<std::vector<size_t>>, //input shapes
+        InferenceEngine::Precision,       //Network precision
+        std::string>;                     //Device name
+
+class MultiplyLayerTest:
+        public testing::WithParamInterface<MultiplyParamsTuple>,
+        public LayerTestsUtils::LayerTestsCommon{
+public:
+    std::shared_ptr<ngraph::Function> fn;
+    static std::string getTestCaseName(const testing::TestParamInfo<MultiplyParamsTuple> &obj);
+protected:
+    void SetUp() override;
+};
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+        InferenceEngine::SizeVector, // Input shapes
+        InferenceEngine::Precision,  // Input precision
+        bool,                        // Across channels
+        bool,                        // Normalize variance
+        double,                      // Epsilon
+        std::string> mvnParams;      // Device name
+
+class MvnLayerTest : public testing::WithParamInterface<mvnParams>, public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<mvnParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/nonzero.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/nonzero.hpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace LayerTestsDefinitions {
+
+using ConfigMap = typename std::map<std::string, std::string>;
+
+using NonZeroLayerTestParamsSet = typename std::tuple<
+    InferenceEngine::SizeVector,          // Input shapes
+    InferenceEngine::Precision,           // Input precision
+    LayerTestsUtils::TargetDevice>;       // Device name
+
+class NonZeroLayerTest : public testing::WithParamInterface<NonZeroLayerTestParamsSet>,
+                         public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<NonZeroLayerTestParamsSet> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/pooling.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/pooling.hpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -17,23 +18,24 @@
 namespace LayerTestsDefinitions {
 
 typedef std::tuple<
-        ngraph::helpers::PoolingTypes,
-        InferenceEngine::SizeVector,
-        InferenceEngine::SizeVector,
-        InferenceEngine::SizeVector,
-        InferenceEngine::SizeVector,
-        ngraph::op::RoundingType,
-        ngraph::op::PadType,
-        bool> poolSpecificParams;
+        ngraph::helpers::PoolingTypes,  // Pooling type, max or avg
+        std::vector<size_t>,            // Kernel size
+        std::vector<size_t>,            // Stride
+        std::vector<size_t>,            // Pad begin
+        std::vector<size_t>,            // Pad end
+        ngraph::op::RoundingType,       // Rounding type
+        ngraph::op::PadType,            // Pad type
+        bool                            // Exclude pad
+> poolSpecificParams;
 typedef std::tuple<
         poolSpecificParams,
-        InferenceEngine::Precision,
-        InferenceEngine::Precision,
-        InferenceEngine::SizeVector,
-        std::string> poolLayerTestParamsSet;
+        InferenceEngine::Precision,     // Net precision
+        std::vector<size_t>,            // Input shape
+        std::string                     // Device name
+> poolLayerTestParamsSet;
 
-class PoolingLayerTest
-        : public LayerTestsUtils::LayerTestsCommonClass<poolLayerTestParamsSet> {
+class PoolingLayerTest : public testing::WithParamInterface<poolLayerTestParamsSet>,
+                         public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<poolLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/prior_box_clustered.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/prior_box_clustered.hpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <vector>
+#include <tuple>
+#include <string>
+#include <map>
+#include <memory>
+#include <set>
+#include <functional>
+#include <gtest/gtest.h>
+
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+#include "details/ie_exception.hpp"
+
+#include "ngraph/opsets/opset1.hpp"
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ngraph_functions/builders.hpp"
+
+typedef std::tuple<
+    std::vector<float>,  // widths
+    std::vector<float>,  // heights
+    bool,                // clip
+    float,               // step_width
+    float,               // step_height
+    float,               // offset
+    std::vector<float>> priorBoxClusteredSpecificParams;
+
+typedef std::tuple<
+    priorBoxClusteredSpecificParams,
+    InferenceEngine::Precision,   // net precision
+    InferenceEngine::SizeVector,  // input shape
+    InferenceEngine::SizeVector,  // image shape
+    std::string> priorBoxClusteredLayerParams;
+
+namespace LayerTestsDefinitions {
+class PriorBoxClusteredLayerTest
+    : public testing::WithParamInterface<priorBoxClusteredLayerParams>,
+      public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<priorBoxClusteredLayerParams>& obj);
+
+protected:
+    InferenceEngine::SizeVector inputShapes;
+    InferenceEngine::SizeVector imageShapes;
+    InferenceEngine::Precision netPrecision;
+    std::vector<float> widths;
+    std::vector<float> heights;
+    std::vector<float> variances;
+    float step_width;
+    float step_height;
+    float offset;
+    bool clip;
+
+    std::vector<std::vector<std::uint8_t>> CalculateRefs() override;
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/proposal.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/proposal.hpp
@@ -1,0 +1,66 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace LayerTestsDefinitions {
+
+namespace proposalTypes {
+
+typedef size_t base_size_type;
+typedef size_t pre_nms_topn_type;
+typedef size_t post_nms_topn_type;
+typedef float nms_thresh_type;
+typedef size_t min_size_type;
+typedef std::vector<float> ratio_type;
+typedef std::vector<float> scale_type;
+typedef bool clip_before_nms_type;
+typedef bool clip_after_nms_type;
+typedef bool normalize_type;
+typedef size_t feat_stride_type;
+typedef float box_size_scale_type;
+typedef float box_coordinate_scale_type;
+typedef std::string framework_type;
+
+};  // namespace proposalTypes
+
+using namespace proposalTypes;
+
+typedef std::tuple<
+        base_size_type,
+        pre_nms_topn_type,
+        post_nms_topn_type,
+        nms_thresh_type,
+        min_size_type,
+        ratio_type,
+        scale_type,
+        clip_before_nms_type,
+        clip_after_nms_type,
+        framework_type> proposalSpecificParams;
+typedef std::tuple<
+        proposalSpecificParams,
+        std::string> proposalLayerTestParamsSet;
+
+class ProposalLayerTest
+        : public testing::WithParamInterface<proposalLayerTestParamsSet>,
+          public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<proposalLayerTestParamsSet> obj);
+    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo &info) const override;
+
+protected:
+    void SetUp() override;
+    void Validate() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reshape.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reshape.hpp
@@ -1,0 +1,35 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+namespace LayerTestsDefinitions {
+typedef std::tuple<
+        bool,                               // SpecialZero
+        InferenceEngine::Precision,         // Network precision
+        std::vector<size_t>,                // Input shapes
+        std::vector<size_t>,                // OutForm Shapes
+        std::string,                        // Device name
+        std::map<std::string, std::string>  // Config
+> reshapeParams;
+
+class ReshapeLayerTest : public testing::WithParamInterface<reshapeParams>,
+                         public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<reshapeParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/select.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/select.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <functional_test_utils/layer_test_utils.hpp>
+
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+        std::vector<std::vector<size_t>>,  // mask, then, else shapes
+        InferenceEngine::Precision,        // then, else precision
+        ngraph::op::AutoBroadcastSpec,     // broadcast
+        std::string> selectTestParams;     // device name
+
+class SelectLayerTest : public testing::WithParamInterface<selectTestParams>, public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo <selectTestParams> &obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/softmax.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/softmax.hpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace LayerTestsDefinitions {
+
+using softMaxLayerTestParams = std::tuple<
+        InferenceEngine::Precision,         // netPrecision
+        InferenceEngine::Layout,            // inputLayout
+        InferenceEngine::SizeVector,        // inputShape
+        size_t,                             // axis
+        std::string,                        // targetDevice
+        std::map<std::string, std::string>  // config
+>;
+
+class SoftMaxLayerTest : public testing::WithParamInterface<softMaxLayerTestParams>,
+                         public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<softMaxLayerTestParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_batch.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_batch.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -18,11 +18,11 @@ using spaceToBatchParamsTuple = typename std::tuple<
         std::vector<size_t>,               // pads_begin
         std::vector<size_t>,               // pads_end
         std::vector<size_t>,               // Input shapes
-        InferenceEngine::Precision,        // Input precision
         InferenceEngine::Precision,        // Network precision
         std::string>;                      // Device name>;
 
-class SpaceToBatchLayerTest : public LayerTestsUtils::LayerTestsCommonClass<spaceToBatchParamsTuple> {
+class SpaceToBatchLayerTest : public testing::WithParamInterface<spaceToBatchParamsTuple>,
+                              public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<spaceToBatchParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/split.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/split.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -15,15 +15,15 @@
 namespace LayerTestsDefinitions {
 
 typedef std::tuple<
-        size_t,
-        size_t,
-        InferenceEngine::Precision,
-        InferenceEngine::Precision,
-        InferenceEngine::SizeVector,
-        std::string> splitParams;
+        size_t,                         // Num splits
+        size_t,                         // Axis
+        InferenceEngine::Precision,     // Net precision
+        std::vector<size_t>,            // Input shapes
+        std::string                     // Target device name
+> splitParams;
 
-class SplitLayerTest
-        : public LayerTestsUtils::LayerTestsCommonClass<splitParams> {
+class SplitLayerTest : public testing::WithParamInterface<splitParams>,
+                       public LayerTestsUtils::LayerTestsCommon {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<splitParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/strided_slice.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/strided_slice.hpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+namespace LayerTestsDefinitions {
+
+using stridedSliceParamsTuple = typename std::tuple<
+        InferenceEngine::SizeVector,       // Input shape
+        std::vector<int64_t>,              // Begin
+        std::vector<int64_t>,              // End
+        std::vector<int64_t>,              // Stride
+        std::vector<int64_t>,              // Begin mask
+        std::vector<int64_t>,              // End mask
+        std::vector<int64_t>,              // New axis mask
+        std::vector<int64_t>,              // Shrink axis mask
+        std::vector<int64_t>,              // Ellipsis axis mask
+        InferenceEngine::Precision,        // Network precision
+        std::string>;                      // Device name>;
+
+class StridedSliceLayerTest : public testing::WithParamInterface<stridedSliceParamsTuple>,
+                              public LayerTestsUtils::LayerTestsCommon {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<stridedSliceParamsTuple> &obj);
+
+protected:
+    void SetUp() override;
+};
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -52,7 +53,6 @@ void ActivationLayerTest::SetUp() {
 }
 
 TEST_P(ActivationLayerTest, CompareWithRefs) {
-    SKIP_IF_CURRENT_TEST_IS_DISABLED()
     InferenceEngine::CNNNetwork cnnNet(fnPtr);
     setNetInOutPrecision(cnnNet, inputPrecision);
     std::string inputName = cnnNet.getInputsInfo().begin()->first;
@@ -101,11 +101,12 @@ TEST_P(ActivationLayerTest, CompareWithRefs) {
     convertFuncToF32(fnPtr, netPrecision);
     auto refOutData = ngraph::helpers::inferFnWithInterp<ngraph::element::Type_t::f32>(fnPtr, inRawData);
     auto thr = FuncTestUtils::GetComparisonThreshold(netPrecision);
+
     size_t outElementsCount = std::accumulate(begin(fnPtr->get_output_shape(0)), end(fnPtr->get_output_shape(0)), 1,
                                               std::multiplies<size_t>());
-    FuncTestUtils::compareRawBuffers(outBlob->cbuffer().as<float *>(), *refOutData[0], outElementsCount,
-                                     outElementsCount,
-                                     thr);
+    FuncTestUtils::compareRawBuffers(outBlob->cbuffer().as<float *>(), *refOutData[0],
+                                                     outElementsCount, outElementsCount,
+                                                     thr);
     fnPtr.reset();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
@@ -37,10 +37,10 @@ std::string ActivationLayerTest::getTestCaseName(const testing::TestParamInfo<ac
     std::ostringstream result;
     const char separator = '_';
     result << activationNames[activationType] << separator;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << separator;
-    result << "inPRC=" << inputPrecision.name() << separator;
-    result << "netPRC=" << netPrecision.name() << separator;
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "inPRC_" << inputPrecision.name() << separator;
+    result << "netPRC_" << netPrecision.name() << separator;
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/add.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/add.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <map>
+#include <ie_core.hpp>
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "single_layer_tests/add.hpp"
+
+namespace LayerTestsDefinitions {
+    std::string AddLayerTest::getTestCaseName(testing::TestParamInfo<addParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    std::string targetDevice;
+    std::map<std::string, std::string> config;
+    std::tie(netPrecision, inputShapes, targetDevice, config) = obj.param;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void AddLayerTest::SetUp() {
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    InferenceEngine::Precision netPrecision;
+    std::tie(netPrecision, inputShapes, targetDevice, configuration) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    auto paramIn = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    IE_ASSERT(paramIn.size() == 2);
+    auto add = std::make_shared<ngraph::opset1::Add>(paramsIn[0], paramsIn[1]);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(add)};
+    function = std::make_shared<ngraph::Function>(results, paramsIn, "Add");
+}
+
+TEST_P(AddLayerTest, CompareWithRefs) {
+    Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -22,12 +22,11 @@ namespace LayerTestsDefinitions {
 
 std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj) {
     std::vector<size_t> inShapes, blockShape, cropsBegin, cropsEnd;
-    InferenceEngine::Precision inPrc, netPrc;
+    InferenceEngine::Precision  netPrc;
     std::string targetName;
-    std::tie(blockShape, cropsBegin, cropsEnd, inShapes, inPrc, netPrc, targetName) = obj.param;
+    std::tie(blockShape, cropsBegin, cropsEnd, inShapes, netPrc, targetName) = obj.param;
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inShapes) << "_";
-    result << "inPRC=" << inPrc.name() << "_";
     result << "netPRC=" << netPrc.name() << "_";
     result << "BS=" << CommonTestUtils::vec2str(blockShape) << "_";
     result << "CB=" << CommonTestUtils::vec2str(cropsBegin) << "_";
@@ -38,20 +37,19 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
 
 void BatchToSpaceLayerTest::SetUp() {
     std::vector<size_t> inputShape, blockShape, cropsBegin, cropsEnd;
-    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, inputPrecision, netPrecision,
-             targetDevice) = this->GetParam();
-
+    InferenceEngine::Precision netPrecision;
+    std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto b2s = ngraph::builder::makeBatchToSpace(paramOuts[0], ngPrc, blockShape, cropsBegin, cropsEnd);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(b2s)};
-    fnPtr = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
+    function = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
 }
 
 TEST_P(BatchToSpaceLayerTest, CompareWithRefs) {
-    inferAndValidate();
+    Run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -21,35 +21,35 @@
 namespace LayerTestsDefinitions {
 
 std::string ConcatLayerTest::getTestCaseName(const testing::TestParamInfo<concatParamsTuple> &obj) {
-    size_t axis;
+    int axis;
     std::vector<std::vector<size_t>> inputShapes;
-    InferenceEngine::Precision netPrecision, inputPrecision;
+    InferenceEngine::Precision netPrecision;
     std::string targetName;
-    std::tie(axis, inputShapes, inputPrecision, netPrecision, targetName) = obj.param;
+    std::tie(axis, inputShapes, netPrecision, targetName) = obj.param;
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
     result << "axis=" << axis << "_";
-    result << "inPRC=" << inputPrecision.name() << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetName << "_";
     return result.str();
 }
 
 void ConcatLayerTest::SetUp() {
-    size_t axis;
+    int axis;
     std::vector<std::vector<size_t>> inputShape;
-    std::tie(axis, inputShape, inputPrecision, netPrecision, targetDevice) = this->GetParam();
+    InferenceEngine::Precision netPrecision;
+    std::tie(axis, inputShape, netPrecision, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, inputShape);
     auto paramOuts = ngraph::helpers::convert2OutputVector(
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto concat = std::make_shared<ngraph::opset1::Concat>(paramOuts, axis);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(concat)};
-    fnPtr = std::make_shared<ngraph::Function>(results, params, "concat");
+    function = std::make_shared<ngraph::Function>(results, params, "concat");
 }
 
 
 TEST_P(ConcatLayerTest, CompareWithRefs) {
-    inferAndValidate();
+    Run();
 };
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -16,21 +16,21 @@
 #include "functional_test_utils/plugin_cache.hpp"
 #include "functional_test_utils/layer_test_utils.hpp"
 
-#include "single_layer_tests/convolution.hpp"
+#include "single_layer_tests/convolution_backprop_data.hpp"
 
 namespace LayerTestsDefinitions {
 
-std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet> obj) {
-    convSpecificParams convParams;
+std::string ConvolutionBackpropDataLayerTest::getTestCaseName(testing::TestParamInfo<convBackpropDataLayerTestParamsSet> obj) {
+    convBackpropDataSpecificParams convBackpropDataParams;
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     std::string targetDevice;
-    std::tie(convParams, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::tie(convBackpropDataParams, netPrecision, inputShapes, targetDevice) = obj.param;
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convBackpropDataParams;
 
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
@@ -46,28 +46,28 @@ std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLay
     return result.str();
 }
 
-void ConvolutionLayerTest::SetUp() {
-    convSpecificParams convParams;
+void ConvolutionBackpropDataLayerTest::SetUp() {
+    convBackpropDataSpecificParams convBackpropDataParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convParams, netPrecision, inputShape, targetDevice) = this->GetParam();
+    std::tie(convBackpropDataParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
     size_t convOutChannels;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convBackpropDataParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto conv = std::dynamic_pointer_cast<ngraph::opset1::Convolution>(
-            ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
-                                             padEnd, dilation, padType, convOutChannels));
-    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(conv)};
-    function = std::make_shared<ngraph::Function>(results, params, "convolution");
+    auto convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(
+            ngraph::builder::makeConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
+                                                         padEnd, dilation, padType, convOutChannels));
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(convBackpropData)};
+    function = std::make_shared<ngraph::Function>(results, params, "convolutionBackpropData");
 }
 
-TEST_P(ConvolutionLayerTest, CompareWithRefs) {
+TEST_P(ConvolutionBackpropDataLayerTest, CompareWithRefs) {
     Run();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/ctc_greedy_decoder.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/ctc_greedy_decoder.cpp
@@ -1,0 +1,145 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <functional>
+#include <cmath>
+#include <memory>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/ctc_greedy_decoder.hpp"
+
+namespace LayerTestsDefinitions {
+std::string CTCGreedyDecoderLayerTest::getTestCaseName(
+    const testing::TestParamInfo<ctcGreedyDecoderParams>& obj) {
+    InferenceEngine::Precision inputPrecision, netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    bool mergeRepeated;
+    std::tie(netPrecision,
+        inputShapes,
+        mergeRepeated,
+        targetDevice) = obj.param;
+
+    std::ostringstream result;
+    const char separator = '_';
+
+    result << "IS="     << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "netPRC=" << netPrecision.name() << separator;
+    result << "merge_repeated=" << std::boolalpha << mergeRepeated << separator;
+    result << "targetDevice=" << targetDevice;
+
+    return result.str();
+}
+
+std::vector<std::vector<std::uint8_t>> CTCGreedyDecoderLayerTest::CalculateRefs() {
+    std::vector<const float *> inRawData;
+    std::vector<InferenceEngine::Blob::Ptr> castedBlobs;
+    for (size_t i = 0; i < inputs.size(); i++) {
+        const auto precision = inputs[i]->getTensorDesc().getPrecision();
+        const auto layout = inputs[i]->getTensorDesc().getLayout();
+        const auto defLayout = InferenceEngine::TensorDesc::getLayoutByDims(inputs[i]->getTensorDesc().getDims());
+
+        if (precision == InferenceEngine::Precision::FP32 && layout == defLayout) {
+            inRawData.push_back(inputs[i]->cbuffer().template as<const float*>());
+        } else {
+            auto castedBlob = FuncTestUtils::copyBlobWithCast<InferenceEngine::Precision::FP32>(inputs[i]);
+            castedBlob = FuncTestUtils::convertBlobLayout(castedBlob, defLayout);
+            inRawData.push_back(castedBlob->cbuffer().template as<const float*>());
+            castedBlobs.push_back(castedBlob);
+        }
+    }
+
+    size_t T_ = inputShapes.at(0);
+    size_t N_ = inputShapes.at(1);
+    size_t C_ = inputShapes.at(2);
+    auto outSize = T_ * N_;
+    float a = 43;
+    const float* probabilities = inRawData[0];
+    const float* sequence_indicators = inRawData[1];
+    auto outBuf = std::vector<float>(outSize);
+    float* output_sequences = outBuf.data();
+
+    for (auto i = 0; i < outSize; i++)
+        output_sequences[i] = -1.0f;
+
+    for (size_t n = 0; n < N_; ++n) {
+        int prev_class_idx = -1;
+        size_t output_index = n * T_;
+
+        for (size_t t = 0; /* check at end */; ++t) {
+            // get maximum probability and its index
+            int max_class_idx = 0;
+
+            const float* probs = probabilities + t * C_ * N_ + n * C_;
+            float max_prob = probs[0];
+            ++probs;
+
+            for (size_t c = 1; c < C_; ++c, ++probs) {
+                if (*probs > max_prob) {
+                    max_class_idx = static_cast<int>(c);
+                    max_prob = *probs;
+                }
+            }
+
+            if (max_class_idx < static_cast<int>(C_) - 1 &&
+                max_class_idx != prev_class_idx) {
+                output_sequences[output_index] = static_cast<float>(max_class_idx);
+                output_index++;
+            }
+
+            prev_class_idx = max_class_idx;
+
+            if (t + 1 == T_ || sequence_indicators[(t + 1) * N_ + n] == 0) {
+                break;
+            }
+        }
+    }
+
+    // Be aligned with test utils ref calulcation method, which returns std::vector<std::vector<uint8_t>>...
+    std::vector<std::vector<uint8_t>> ret(1);
+    for (auto& val : outBuf) {
+        uint8_t* u8_val = reinterpret_cast<uint8_t*>(&val);
+        ret[0].push_back(u8_val[0]);
+        ret[0].push_back(u8_val[1]);
+        ret[0].push_back(u8_val[2]);
+        ret[0].push_back(u8_val[3]);
+    }
+
+    return ret;
+}
+
+void CTCGreedyDecoderLayerTest::SetUp() {
+    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
+    std::tie(netPrecision, inputShapes, mergeRepeated, targetDevice) = GetParam();
+    sequenceLengths = { inputShapes.at(0), inputShapes.at(1) };
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes, sequenceLengths });
+    auto paramsOut = ngraph::helpers::convert2OutputVector(
+        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    auto ctcGreedyDecoder = std::make_shared<ngraph::opset1::CTCGreedyDecoder>(
+        paramsOut[0],
+        paramsOut[1],
+        mergeRepeated);
+
+    ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(ctcGreedyDecoder) };
+    function = std::make_shared<ngraph::Function>(results, paramsIn, "Grn");
+}
+
+TEST_P(CTCGreedyDecoderLayerTest, CompareWithRefs) {
+    //std::vector<std::shared_ptr<float*>> CalculateRefs();
+    Run();
+};
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/cum_sum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/cum_sum.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/cum_sum.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string CumSumLayerTest::getTestCaseName(testing::TestParamInfo<cumSumParams> obj) {
+    InferenceEngine::SizeVector inputShapes;
+    InferenceEngine::Precision inputPrecision;
+    int64_t axis;
+    bool exclusive, reverse;
+    std::string targetDevice;
+    std::tie(inputShapes, inputPrecision, axis, exclusive, reverse, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "Precision=" << inputPrecision.name() << "_";
+    result << "Axis=" << axis << "_";
+    result << "Exclusive=" << (exclusive ? "TRUE" : "FALSE") << "_";
+    result << "Reverse=" << (reverse ? "TRUE" : "FALSE") << "_";
+    result << "TargetDevice=" << targetDevice;
+    return result.str();
+}
+
+void CumSumLayerTest::SetUp() {
+    InferenceEngine::SizeVector inputShapes;
+    InferenceEngine::Precision inputPrecision;
+    bool exclusive, reverse;
+    int64_t axis;
+    std::tie(inputShapes, inputPrecision, axis, exclusive, reverse, targetDevice) = this->GetParam();
+    auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    ngraph::ParameterVector paramVector;
+    auto paramData = std::make_shared<ngraph::opset1::Parameter>(inType, ngraph::Shape(inputShapes));
+    paramVector.push_back(paramData);
+
+    auto axisNode = std::make_shared<ngraph::op::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{}, std::vector<int64_t>{axis})->output(0);
+
+    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramVector));
+    auto cumSum = std::dynamic_pointer_cast<ngraph::op::CumSum>(ngraph::builder::makeCumSum(paramOuts[0], axisNode, exclusive, reverse));
+
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(cumSum)};
+    function = std::make_shared<ngraph::Function>(results, paramVector, "cumsum");
+}
+
+TEST_P(CumSumLayerTest, CompareWithRefs) {
+    Run();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
@@ -1,0 +1,155 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+#include "common_test_utils/common_layers_params.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "common_test_utils/test_common.hpp"
+#include "common_test_utils/test_constants.hpp"
+#include "common_test_utils/xml_net_builder/ir_net.hpp"
+#include "common_test_utils/xml_net_builder/xml_filler.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+#include "ie_core.hpp"
+#include "single_layer_tests/eltwise.hpp"
+
+using namespace EltwiseTestNamespace;
+
+std::string EltwiseLayerTest::getTestCaseName(testing::TestParamInfo<eltwiseLayerTestParamsSet> obj) {
+    EltwiseOpType op;
+    ParameterInputIdx primary_input_idx;
+    InputLayerType secondary_input_type;
+    InferenceEngine::Precision prec;
+    InferenceEngine::SizeVector vec;
+    LayerTestsUtils::TargetDevice dev;
+    std::map<std::string, std::string> additional_config;
+    std::tie(op, primary_input_idx, secondary_input_type, prec, vec, dev, additional_config) = obj.param;
+
+    std::ostringstream result;
+    result << "operation=" << EltwiseOpType_to_string(op) << "_";
+    result << "netPRC=" << prec.name() << "_";
+    result << "primaryInputIdx=" << primary_input_idx << "_";
+    result << "secondaryInputType=" << InputLayerType_to_string(secondary_input_type) << "_";
+    result << "inputShapes=" << CommonTestUtils::vec2str(vec) << "_";
+    result << "targetDevice=" << dev;
+    return result.str();
+}
+
+void EltwiseLayerTest::SetUp() {
+    EltwiseOpType op;
+    ParameterInputIdx primary_input_idx;
+    InputLayerType secondary_input_type;
+    InferenceEngine::SizeVector inputShape;
+    InferenceEngine::Precision netPrecision;
+    ngraph::ParameterVector parameter_inputs;
+    std::map<std::string, std::string> additional_config;
+    std::tie(op, primary_input_idx, secondary_input_type, netPrecision, inputShape, targetDevice, additional_config) = this->GetParam();
+    configuration.insert(additional_config.begin(), additional_config.end());
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    std::shared_ptr<ngraph::Node> input0_node;
+    std::shared_ptr<ngraph::Node> input1_node;
+    auto primary_input = ngraph::builder::makeParams(ngPrc, { inputShape })[0];
+
+    switch (secondary_input_type) {
+    case InputLayerType::CONSTANT:
+    {
+        auto shape_total = 1;
+        for (auto dim : inputShape) {
+            shape_total *= dim;
+        }
+
+        const float min = -10;
+        const float max = 10;
+        const float range = max - min;
+        const float step = range / shape_total;
+
+        std::vector<float> const_vec(shape_total);
+        for (int i = 0; i < shape_total; i++) {
+            const_vec[i] = min + step * i;
+        }
+
+        auto const_vals = ngraph::builder::makeConstant(ngPrc, inputShape, const_vec);
+        parameter_inputs.push_back(primary_input);
+
+        if (primary_input_idx == 0) {
+            input0_node = primary_input;
+            input1_node = const_vals;
+        } else {
+            input0_node = const_vals;
+            input1_node = primary_input;
+        }
+        break;
+    }
+    case InputLayerType::PARAMETER:
+    {
+        auto secondary_input = ngraph::builder::makeParams(ngPrc, { inputShape })[0];
+        if (primary_input_idx == 0) {
+            parameter_inputs.push_back(primary_input);
+            parameter_inputs.push_back(secondary_input);
+            input0_node = primary_input;
+            input1_node = secondary_input;
+        } else {
+            parameter_inputs.push_back(secondary_input);
+            parameter_inputs.push_back(primary_input);
+            input0_node = secondary_input;
+            input1_node = primary_input;
+        }
+        break;
+    }
+    default:
+        ASSERT_EQ("unknown input type", "");
+        break;
+    }
+
+    std::shared_ptr<ngraph::op::util::BinaryElementwiseArithmetic> ngraph_op = nullptr;
+    switch (op) {
+    case EltwiseOpType::ADD:
+        ngraph_op = std::make_shared<ngraph::op::Add>(input0_node, input1_node);
+        break;
+    case EltwiseOpType::MULTIPLY:
+        ngraph_op = std::make_shared<ngraph::op::Multiply>(input0_node, input1_node);
+        break;
+    case EltwiseOpType::SUBSTRACT:
+        ngraph_op = std::make_shared<ngraph::op::Subtract>(input0_node, input1_node);
+        break;
+    default:
+        ASSERT_EQ(std::string("Unknown Eltwise operation type: ") + EltwiseOpType_to_string(op), "");
+        break;
+    }
+    function = std::make_shared<ngraph::Function>(ngraph_op, parameter_inputs, "Eltwise_op");
+}
+
+const char* EltwiseTestNamespace::InputLayerType_to_string(InputLayerType lt) {
+    switch (lt) {
+    case InputLayerType::CONSTANT:
+        return "CONSTANT";
+    case InputLayerType::PARAMETER:
+        return "PARAMETER";
+    default:
+        return "NOT_SUPPORTED_INPUT_LAYER_TYPE";
+    }
+}
+
+const char* EltwiseTestNamespace::EltwiseOpType_to_string(EltwiseOpType eOp) {
+    switch (eOp) {
+    case EltwiseOpType::ADD:
+        return "Sum";
+    case EltwiseOpType::MULTIPLY:
+        return "Prod";
+    case EltwiseOpType::SUBSTRACT:
+        return "Sub";
+    default:
+        return "NOT_SUPPORTED_ELTWISE_OPERATION";
+    }
+}
+
+TEST_P(EltwiseLayerTest, basic) {
+    Run();
+}

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/equal.hpp"
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <ie_core.hpp>
+
+
+namespace LayerTestsDefinitions {
+
+std::string EqualLayerTest::getTestCaseName(const testing::TestParamInfo<EqualTestParam>& obj) {
+    InferenceEngine::Precision inPrecision;
+    InferenceEngine::Precision outPrecision;
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    std::string targetDevice;
+
+    std::tie(inputShapes, inPrecision, outPrecision, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "inPrc=" << inPrecision.name() << "_";
+    result << "outPrc=" << outPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+
+    return result.str();
+}
+
+void EqualLayerTest::SetUp() {
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    InferenceEngine::Precision inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
+
+    std::tie(inputShapes, inputPrecision, outPrc, targetDevice) = this->GetParam();
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    auto paramsVector = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    IE_ASSERT(paramsVector.size() == 2);
+
+    auto equalOp = std::make_shared<ngraph::opset3::Equal>(paramsVector[0], paramsVector[1]);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(equalOp)};
+
+    function = std::make_shared<ngraph::Function>(results, paramsVector, "Equal");
+}
+
+TEST_P(EqualLayerTest, CompareWithRefs) {
+    Run();
+
+    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
+        PluginCache::get().reset();
+    }
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "single_layer_tests/extract_image_patches.hpp"
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+
+namespace LayerTestsDefinitions {
+
+std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj) {
+    std::vector<size_t> inputShape, kernel, strides, rates;
+    ngraph::op::PadType pad_type;
+    InferenceEngine::Precision netPrc;
+    std::string targetName;
+    std::tie(inputShape, kernel, strides, rates, pad_type, netPrc, targetName) = obj.param;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "netPRC=" << netPrc.name() << "_";
+    result << "K=" << CommonTestUtils::vec2str(kernel) << "_";
+    result << "S=" << CommonTestUtils::vec2str(strides) << "_";
+    result << "R=" << CommonTestUtils::vec2str(rates) << "_";
+    result << "P=" << pad_type << "_";
+    result << "targetDevice=" << targetName;
+    return result.str();
+}
+
+void ExtractImagePatchesTest::SetUp() {
+    std::vector<size_t> inputShape, kernel, strides, rates;
+    ngraph::op::PadType pad_type;
+    InferenceEngine::Precision netPrecision;
+    std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    auto inputNode = std::make_shared<ngraph::opset1::Parameter>(ngPrc, ngraph::Shape(inputShape));
+    ngraph::ParameterVector params = {inputNode};
+
+    auto extImgPatches = std::make_shared<ngraph::opset3::ExtractImagePatches>(
+        inputNode, ngraph::Shape(kernel), ngraph::Strides(strides), ngraph::Shape(rates), pad_type);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(extImgPatches)};
+    function = std::make_shared<ngraph::Function>(results, params, "ExtractImagePatches");
+}
+
+TEST_P(ExtractImagePatchesTest, CompareWithRefs) {
+    Run();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
@@ -1,0 +1,64 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/fake_quantize.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string FakeQuantizeLayerTest::getTestCaseName(testing::TestParamInfo<fqLayerTestParamsSet> obj) {
+    fqSpecificParams fqParams;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(fqParams, netPrecision, inputShapes, targetDevice) = obj.param;
+    size_t levels;
+    std::vector<size_t> constShape;
+    std::tie(levels, constShape) = fqParams;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "CS=" << CommonTestUtils::vec2str(constShape) << "_";
+    result << "LEVELS=" << levels << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void FakeQuantizeLayerTest::SetUp() {
+    fqSpecificParams fqParams;
+    std::vector<size_t> inputShape;
+    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
+    std::tie(fqParams, netPrecision, inputShape, targetDevice) = this->GetParam();
+    InferenceEngine::SizeVector kernel, stride, dilation;
+    size_t levels;
+    std::vector<size_t> constShape;
+    std::tie(levels, constShape) = fqParams;
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    auto fq = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(ngraph::builder::makeFakeQuantize(paramOuts[0], ngPrc, levels, constShape));
+
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(fq)};
+    function = std::make_shared<ngraph::Function>(results, params, "fakeQuantize");
+}
+
+TEST_P(FakeQuantizeLayerTest, CompareWithRefs) {
+    Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/greater.hpp"
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <ie_core.hpp>
+
+
+namespace LayerTestsDefinitions {
+
+std::string GreaterLayerTest::getTestCaseName(const testing::TestParamInfo<GreaterTestParam>& obj) {
+    InferenceEngine::Precision inPrecision;
+    InferenceEngine::Precision outPrecision;
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    std::string targetDevice;
+
+    std::tie(inputShapes, inPrecision, outPrecision, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "inPrc=" << inPrecision.name() << "_";
+    result << "outPrc=" << outPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+
+    return result.str();
+}
+
+void GreaterLayerTest::SetUp() {
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    InferenceEngine::Precision inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
+
+    std::tie(inputShapes, inputPrecision, outPrc, targetDevice) = this->GetParam();
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    auto paramsVector = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    IE_ASSERT(paramsVector.size() == 2);
+
+    auto equalOp = std::make_shared<ngraph::opset3::Greater>(paramsVector[0], paramsVector[1]);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(equalOp)};
+
+    function = std::make_shared<ngraph::Function>(results, paramsVector, "Greater");
+}
+
+TEST_P(GreaterLayerTest, CompareWithRefs) {
+    Run();
+
+    if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
+        PluginCache::get().reset();
+    }
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <functional>
+#include <cmath>
+#include <memory>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/grn.hpp"
+
+namespace LayerTestsDefinitions {
+std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams>& obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    float bias;
+    std::tie(netPrecision,
+        inputShapes,
+        bias,
+        targetDevice) = obj.param;
+
+    std::ostringstream result;
+    const char separator = '_';
+
+    result << "IS="     << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "netPRC=" << netPrecision.name() << separator;
+    result << "bias="   << bias << separator;
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void GrnLayerTest::SetUp() {
+    InferenceEngine::Precision netPrecision;
+    std::tie(netPrecision, inputShapes, bias, targetDevice) = GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });
+    auto paramsOut = ngraph::helpers::convert2OutputVector(
+        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    auto grn = std::make_shared<ngraph::opset1::GRN>(paramsOut[0], bias);
+    ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(grn) };
+    function = std::make_shared<ngraph::Function>(results, paramsIn, "Grn");
+}
+
+TEST_P(GrnLayerTest, CompareWithRefs) {
+    Run();
+};
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -16,21 +16,21 @@
 #include "functional_test_utils/plugin_cache.hpp"
 #include "functional_test_utils/layer_test_utils.hpp"
 
-#include "single_layer_tests/convolution.hpp"
+#include "single_layer_tests/group_convolution.hpp"
 
 namespace LayerTestsDefinitions {
 
-std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet> obj) {
-    convSpecificParams convParams;
+std::string GroupConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<groupConvLayerTestParamsSet> obj) {
+    groupConvSpecificParams groupConvParams;
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     std::string targetDevice;
-    std::tie(convParams, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::tie(groupConvParams, netPrecision, inputShapes, targetDevice) = obj.param;
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+    size_t convOutChannels, numGroups;
+    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
 
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
@@ -40,34 +40,35 @@ std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLay
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
     result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
     result << "O=" << convOutChannels << "_";
+    result << "G=" << numGroups << "_";
     result << "AP=" << padType << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
     return result.str();
 }
 
-void ConvolutionLayerTest::SetUp() {
-    convSpecificParams convParams;
+void GroupConvolutionLayerTest::SetUp() {
+    groupConvSpecificParams groupConvParams;
     std::vector<size_t> inputShape;
     auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-    std::tie(convParams, netPrecision, inputShape, targetDevice) = this->GetParam();
+    std::tie(groupConvParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;
     std::vector<ptrdiff_t> padBegin, padEnd;
-    size_t convOutChannels;
-    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
+    size_t convOutChannels, numGroups;
+    std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
-    auto conv = std::dynamic_pointer_cast<ngraph::opset1::Convolution>(
-            ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
-                                             padEnd, dilation, padType, convOutChannels));
-    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(conv)};
-    function = std::make_shared<ngraph::Function>(results, params, "convolution");
+    auto groupConv = std::dynamic_pointer_cast<ngraph::opset1::GroupConvolution>(
+            ngraph::builder::makeGroupConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
+                                             padEnd, dilation, padType, convOutChannels, numGroups));
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConv)};
+    function = std::make_shared<ngraph::Function>(results, params, "groupConvolution");
 }
 
-TEST_P(ConvolutionLayerTest, CompareWithRefs) {
+TEST_P(GroupConvolutionLayerTest, CompareWithRefs) {
     Run();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <functional>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "single_layer_tests/lrn.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string LrnLayerTest::getTestCaseName(testing::TestParamInfo<lrnLayerTestParamsSet> obj) {
+    double alpha;
+    size_t beta, bias, size;
+    InferenceEngine::Precision  netPrecision;
+    std::vector<size_t> inputShapes;
+    std::string targetDevice;
+    std::tie(alpha, beta, bias, size, netPrecision, inputShapes, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    const char separator = '_';
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "Alpha=" << alpha << separator;
+    result << "Beta=" << beta << separator;
+    result << "Bias=" << bias << separator;
+    result << "Size=" << size << separator;
+    result << "netPRC=" << netPrecision.name() << separator;
+    result << "targetDevice=" << targetDevice;
+
+    return result.str();
+}
+
+void LrnLayerTest::SetUp() {
+    std::vector<size_t> inputShapes;
+    auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
+    size_t alpha, beta, bias, size;
+    std::tie(alpha, beta, bias, size, netPrecision, inputShapes, targetDevice) = GetParam();
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    auto paramIn =
+        ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    auto lrn = std::make_shared<ngraph::opset1::LRN>(paramIn[0], alpha, beta, bias, size);
+    ngraph::ResultVector results {std::make_shared<ngraph::opset1::Result>(lrn)};
+    function = std::make_shared<ngraph::Function>(results, params, "lrn");
+}
+
+TEST_P(LrnLayerTest, CompareWithRefs) {
+    Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/maximum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/maximum.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <debug.h>
+#include "ie_core.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/precision_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "single_layer_tests/maximum.hpp"
+
+namespace LayerTestsDefinitions {
+    std::string MaximumLayerTest::getTestCaseName(const testing::TestParamInfo<MaximumParamsTuple> &obj) {
+        std::vector<std::vector<size_t>> inputShapes;
+        InferenceEngine::Precision netPrecision;
+        std::string targetName;
+        std::tie(inputShapes, netPrecision, targetName) = obj.param;
+        std::ostringstream results;
+
+        results << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+        results << "netPRC=" << netPrecision.name() << "_";
+        results << "targetDevice=" << targetName << "_";
+        return results.str();
+    }
+
+    void MaximumLayerTest::SetUp() {
+        std::vector<std::vector<size_t>> inputShapes;
+        InferenceEngine::Precision netPrecision;
+        std::tie(inputShapes, netPrecision, targetDevice) = this->GetParam();
+        const std::size_t inputDim = InferenceEngine::details::product(inputShapes[0]);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        std::vector<size_t> shapeInput{1, inputDim};
+        auto input = ngraph::builder::makeParams(ngPrc, {shapeInput});
+        auto constMul = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{1}, std::vector<float>{-1.0f});
+        auto max = std::make_shared<ngraph::opset1::Maximum>(input[0], constMul);
+        function = std::make_shared<ngraph::Function>(max, input, "maximum");
+    }
+
+    TEST_P(MaximumLayerTest, CompareWithRefs){
+        Run();
+    };
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/multiply.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/multiply.cpp
@@ -1,0 +1,49 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <debug.h>
+#include "ie_core.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/precision_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "single_layer_tests/multiply.hpp"
+
+namespace LayerTestsDefinitions {
+    std::string MultiplyLayerTest::getTestCaseName(const testing::TestParamInfo<MultiplyParamsTuple> &obj) {
+        std::vector<std::vector<size_t>> inputShapes;
+        InferenceEngine::Precision netPrecision;
+        std::string targetName;
+        std::tie(inputShapes, netPrecision, targetName) = obj.param;
+        std::ostringstream results;
+
+        results << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+        results << "netPRC=" << netPrecision.name() << "_";
+        results << "targetDevice=" << targetName << "_";
+        return results.str();
+    }
+
+    void MultiplyLayerTest::SetUp() {
+        std::vector<std::vector<size_t>> inputShapes;
+        InferenceEngine::Precision netPrecision;
+        std::tie(inputShapes, netPrecision, targetDevice) = this->GetParam();
+        const std::size_t input_dim = InferenceEngine::details::product(inputShapes[0]);
+        auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+        std::vector<size_t> shape_input{1, input_dim};
+        auto input = ngraph::builder::makeParams(ngPrc, {shape_input});
+        auto const_mul = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{1}, std::vector<float>{-1.0f});
+        auto mul = std::make_shared<ngraph::opset1::Multiply>(input[0], const_mul);
+        function = std::make_shared<ngraph::Function>(mul, input, "multiply");
+    }
+
+    TEST_P(MultiplyLayerTest, CompareWithRefs){
+        Run();
+    };
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/mvn.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string MvnLayerTest::getTestCaseName(testing::TestParamInfo<mvnParams> obj) {
+    InferenceEngine::SizeVector inputShapes;
+    InferenceEngine::Precision inputPrecision;
+    bool acrossChannels, normalizeVariance;
+    double eps;
+    std::string targetDevice;
+    std::tie(inputShapes, inputPrecision, acrossChannels, normalizeVariance, eps, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "Precision=" << inputPrecision.name() << "_";
+    result << "AcrossChannels=" << (acrossChannels ? "TRUE" : "FALSE") << "_";
+    result << "NormalizeVariance=" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
+    result << "Epsilon=" << eps << "_";
+    result << "TargetDevice=" << targetDevice;
+    return result.str();
+}
+
+void MvnLayerTest::SetUp() {
+    InferenceEngine::SizeVector inputShapes;
+    InferenceEngine::Precision inputPrecision;
+    bool acrossChanels, normalizeVariance;
+    double eps;
+    std::tie(inputShapes, inputPrecision, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();
+    auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    auto param = ngraph::builder::makeParams(inType, {inputShapes});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
+    auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(paramOuts[0], acrossChanels, normalizeVariance, eps));
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
+    function = std::make_shared<ngraph::Function>(results, param, "mvn");
+}
+
+TEST_P(MvnLayerTest, CompareWithRefs) {
+    Run();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/nonzero.cpp
@@ -1,0 +1,52 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/nonzero.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "ie_core.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace LayerTestsDefinitions {
+
+std::string NonZeroLayerTest::getTestCaseName(testing::TestParamInfo<NonZeroLayerTestParamsSet> obj) {
+    std::vector<size_t> inputShape;
+    InferenceEngine::Precision inputPrecision;
+    std::string targetDevice;
+    std::tie(inputShape, inputPrecision, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "inPRC=" << inputPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void NonZeroLayerTest::SetUp() {
+    SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
+    auto inputShape     = std::vector<std::size_t>{};
+    auto inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
+    std::tie(inputShape, inputPrecision, targetDevice) = GetParam();
+
+    const auto& precision = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    const auto& paramNode = std::make_shared<ngraph::opset1::Parameter>(precision, ngraph::Shape(inputShape));
+
+    auto nonZeroOp = std::make_shared<ngraph::opset3::NonZero>(paramNode->output(0));
+
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(nonZeroOp)};
+    function = std::make_shared<ngraph::Function>(results, ngraph::ParameterVector{paramNode}, "non_zero");
+}
+
+TEST_P(NonZeroLayerTest, CompareWithReference) {
+    Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
@@ -1,4 +1,5 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -23,10 +24,10 @@ namespace LayerTestsDefinitions {
 
 std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTestParamsSet> obj) {
     poolSpecificParams poolParams;
-    InferenceEngine::Precision inputPrecision, netPrecision;
+    InferenceEngine::Precision netPrecision;
     std::vector<size_t> inputShapes, newInputShapes;
     std::string targetDevice;
-    std::tie(poolParams, inputPrecision, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::tie(poolParams, netPrecision, inputShapes, targetDevice) = obj.param;
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -48,13 +49,12 @@ std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTe
     }
     result << "K" << CommonTestUtils::vec2str(kernel) << "_";
     result << "S" << CommonTestUtils::vec2str(stride) << "_";
-    result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";;
+    result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
     if (padType == ngraph::op::PadType::EXPLICIT) {
         result << "Rounding=" << roundingType << "_";
     }
     result << "AutoPad=" << padType << "_";
-    result << "inPRC=" << inputPrecision.name() << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
     return result.str();
@@ -63,7 +63,8 @@ std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTe
 void PoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     std::vector<size_t> inputShape;
-    std::tie(poolParams, inputPrecision, netPrecision, inputShape, targetDevice) = this->GetParam();
+    InferenceEngine::Precision netPrecision;
+    std::tie(poolParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;
     std::vector<size_t> padBegin, padEnd;
@@ -91,10 +92,10 @@ void PoolingLayerTest::SetUp() {
     }
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(pooling)};
-    fnPtr = std::make_shared<ngraph::Function>(results, params, "pooling");
+    function = std::make_shared<ngraph::Function>(results, params, "pooling");
 }
 
 TEST_P(PoolingLayerTest, CompareWithRefs) {
-    inferAndValidate();
+    Run();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/prior_box_clustered.cpp
@@ -1,0 +1,185 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <functional>
+#include <cmath>
+#include <memory>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ie_precision.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/prior_box_clustered.hpp"
+#include "ngraph_ops/prior_box_clustered_ie.hpp"
+
+namespace LayerTestsDefinitions {
+std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParamInfo<priorBoxClusteredLayerParams>& obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes, imageShapes;
+    std::string targetDevice;
+    priorBoxClusteredSpecificParams specParams;
+    std::tie(specParams,
+        netPrecision,
+        inputShapes,
+        imageShapes,
+        targetDevice) = obj.param;
+
+    std::vector<float> widths, heights, variances;
+    float step_width, step_height, offset;
+    bool clip;
+    std::tie(widths,
+        heights,
+        clip,
+        step_width,
+        step_height,
+        offset,
+        variances) = specParams;
+
+    std::ostringstream result;
+    const char separator = '_';
+
+    result << "IS="      << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "imageS="  << CommonTestUtils::vec2str(imageShapes) << separator;
+    result << "netPRC="  << netPrecision.name()   << separator;
+    result << "widths="  << CommonTestUtils::vec2str(widths)  << separator;
+    result << "heights=" << CommonTestUtils::vec2str(heights) << separator;
+    result << "variances=";
+    if (variances.empty())
+        result << "()" << separator;
+    else
+        result << CommonTestUtils::vec2str(variances) << separator;
+    result << "stepWidth="  << step_width  << separator;
+    result << "stepHeight=" << step_height << separator;
+    result << "offset="     << offset      << separator;
+    result << "clip=" << std::boolalpha << clip << separator;
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+std::vector<std::vector<std::uint8_t>> PriorBoxClusteredLayerTest::CalculateRefs() {
+    size_t numPriors = widths.size();
+    const size_t layerWidth = inputShapes[3];
+    const size_t layerHeight = inputShapes[2];
+    size_t imgWidth = imageShapes[3];
+    size_t imgHeight = imageShapes[2];
+
+    if (variances.empty())
+        variances.push_back(0.1f);
+    size_t varSize = variances.size();
+
+    size_t topDataOffset = 4 * layerWidth * layerHeight * numPriors;
+    size_t outSize = 2 * topDataOffset;
+    auto outBuf = std::vector<float>(outSize);
+    float* topData_0 = outBuf.data();
+    float* topData_1 = outBuf.data() + topDataOffset;
+
+    if (targetDevice.find(CommonTestUtils::DEVICE_GPU) != std::string::npos) {
+        //GPU inits buffers with 0.0f
+        for (auto i = 0; i < outSize; i++)
+            topData_0[i] = 0.0f;
+    }
+
+    float stepW = step_width;
+    float stepH = step_height;
+    if (stepW == 0 && stepH == 0) {
+        stepW = static_cast<float>(imgWidth) / layerWidth;
+        stepH = static_cast<float>(imgHeight) / layerHeight;
+    }
+
+    for (size_t h = 0; h < layerHeight; ++h) {
+        for (size_t w = 0; w < layerWidth; ++w) {
+            float center_x = (w + offset) * stepW;
+            float center_y = (h + offset) * stepH;
+
+            for (size_t s = 0; s < numPriors; ++s) {
+                float box_width = widths[s];
+                float box_height = heights[s];
+
+                float xmin = (center_x - box_width / 2.0f) / imgWidth;
+                float ymin = (center_y - box_height / 2.0f) / imgHeight;
+                float xmax = (center_x + box_width / 2.0f) / imgWidth;
+                float ymax = (center_y + box_height / 2.0f) / imgHeight;
+
+                if (clip) {
+                    xmin = (std::min)((std::max)(xmin, 0.0f), 1.0f);
+                    ymin = (std::min)((std::max)(ymin, 0.0f), 1.0f);
+                    xmax = (std::min)((std::max)(xmax, 0.0f), 1.0f);
+                    ymax = (std::min)((std::max)(ymax, 0.0f), 1.0f);
+                }
+
+                topData_0[h * layerWidth * numPriors * 4 + w * numPriors * 4 + s * 4 + 0] = xmin;
+                topData_0[h * layerWidth * numPriors * 4 + w * numPriors * 4 + s * 4 + 1] = ymin;
+                topData_0[h * layerWidth * numPriors * 4 + w * numPriors * 4 + s * 4 + 2] = xmax;
+                topData_0[h * layerWidth * numPriors * 4 + w * numPriors * 4 + s * 4 + 3] = ymax;
+
+                for (int j = 0; j < varSize; j++)
+                    topData_1[h * layerWidth * numPriors * varSize + w * numPriors * varSize +
+                    s * varSize +
+                    j] = variances[j];
+            }
+        }
+    }
+
+    // Be aligned with test utils ref calulcation method, which returns std::vector<std::vector<uint8_t>>...
+    std::vector<std::vector<uint8_t>> ret(1);
+    for (auto& val : outBuf) {
+        uint8_t* u8_val = reinterpret_cast<uint8_t*>(&val);
+        ret[0].push_back(u8_val[0]);
+        ret[0].push_back(u8_val[1]);
+        ret[0].push_back(u8_val[2]);
+        ret[0].push_back(u8_val[3]);
+    }
+
+    return ret;
+}
+
+void PriorBoxClusteredLayerTest::SetUp() {
+    priorBoxClusteredSpecificParams specParams;
+    std::tie(specParams, netPrecision,
+        inputShapes, imageShapes, targetDevice) = GetParam();
+
+    std::tie(widths,
+        heights,
+        clip,
+        step_width,
+        step_height,
+        offset,
+        variances) = specParams;
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes, imageShapes });
+    auto paramsOut = ngraph::helpers::convert2OutputVector(
+        ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+
+    ngraph::op::PriorBoxClusteredAttrs attributes;
+    attributes.widths = widths;
+    attributes.heights = heights;
+    attributes.clip = clip;
+    attributes.step_widths = step_width;
+    attributes.step_heights = step_height;
+    attributes.offset = offset;
+    attributes.variances = variances;
+
+    auto priorBoxClustered = std::make_shared<ngraph::op::PriorBoxClusteredIE>(
+        paramsOut[0],
+        paramsOut[1],
+        attributes);
+
+    ngraph::ResultVector results{ std::make_shared<ngraph::opset1::Result>(priorBoxClustered) };
+    function = std::make_shared<ngraph::Function>(results, paramsIn, "PB_Clustered");
+}
+
+TEST_P(PriorBoxClusteredLayerTest, CompareWithRefs) {
+    Run();
+};
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/proposal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/proposal.cpp
@@ -1,0 +1,154 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/proposal.hpp"
+
+namespace LayerTestsDefinitions {
+
+const normalize_type normalize = true;
+const feat_stride_type feat_stride = 1;
+const box_size_scale_type box_size_scale = 2.0f;
+const box_coordinate_scale_type box_coordinate_scale = 2.0f;
+
+std::string ProposalLayerTest::getTestCaseName(testing::TestParamInfo<proposalLayerTestParamsSet> obj) {
+    proposalSpecificParams proposalParams;
+
+    std::string targetDevice;
+    std::tie(proposalParams, targetDevice) = obj.param;
+
+    base_size_type base_size;
+    pre_nms_topn_type pre_nms_topn;
+    post_nms_topn_type post_nms_topn;
+    nms_thresh_type nms_thresh;
+    min_size_type min_size;
+    ratio_type ratio;
+    scale_type scale;
+    clip_before_nms_type clip_before_nms;
+    clip_after_nms_type clip_after_nms;
+    framework_type framework;
+    std::tie(base_size, pre_nms_topn,
+             post_nms_topn,
+             nms_thresh,
+             min_size,
+             ratio,
+             scale,
+             clip_before_nms,
+             clip_after_nms,
+             framework) = proposalParams;
+
+    std::ostringstream result;
+    result << "base_size=" << base_size << "_";
+    result << "pre_nms_topn=" << pre_nms_topn << "_";
+    result << "post_nms_topn=" << post_nms_topn << "_";
+    result << "nms_thresh=" << nms_thresh << "_";
+    result << "feat_stride=" << feat_stride << "_";
+    result << "min_size=" << min_size << "_";
+    result << "ratio = " << CommonTestUtils::vec2str(ratio) << "_";
+    result << "scale = " << CommonTestUtils::vec2str(scale) << "_";
+    result << "clip_before_nms=" << clip_before_nms << "_";
+    result << "clip_after_nms=" << clip_after_nms << "_";
+    result << "normalize=" << normalize << "_";
+    result << "box_size_scale=" << box_size_scale << "_";
+    result << "box_coordinate_scale=" << box_coordinate_scale << "_";
+    result << "framework=" << framework << "_";
+    result << "targetDevice=" << targetDevice;
+
+    return result.str();
+}
+
+void ProposalLayerTest::SetUp() {
+    proposalSpecificParams proposalParams;
+
+    std::tie(proposalParams, targetDevice) = this->GetParam();
+    base_size_type base_size;
+    pre_nms_topn_type pre_nms_topn;
+    post_nms_topn_type post_nms_topn;
+    nms_thresh_type nms_thresh;
+    min_size_type min_size;
+    ratio_type ratio;
+    scale_type scale;
+    clip_before_nms_type clip_before_nms;
+    clip_after_nms_type clip_after_nms;
+    framework_type framework;
+
+    std::tie(base_size, pre_nms_topn,
+             post_nms_topn,
+             nms_thresh,
+             min_size,
+             ratio,
+             scale,
+             clip_before_nms,
+             clip_after_nms,
+             framework) = proposalParams;
+
+    size_t bottom_w = base_size;
+    size_t bottom_h = base_size;
+    size_t num_anchors = ratio.size() * scale.size();
+
+    std::vector<size_t> scoresShape = {1, 2 * num_anchors, bottom_h, bottom_w};
+    std::vector<size_t> boxesShape  = {1, 4 * num_anchors, bottom_h, bottom_w};
+    std::vector<size_t> imageInfoShape = {3};
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(InferenceEngine::Precision::FP16);
+    auto params = ngraph::builder::makeParams(ngPrc, {{"scores", scoresShape}, {"boxes", boxesShape}, {"image_info", imageInfoShape}});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    auto proposal = std::dynamic_pointer_cast<ngraph::opset1::Proposal>(
+             ngraph::builder::makeProposal(paramOuts[0], paramOuts[1], paramOuts[2], ngPrc,
+                                           base_size,
+                                           pre_nms_topn,
+                                           post_nms_topn,
+                                           nms_thresh,
+                                           feat_stride,
+                                           min_size,
+                                           ratio,
+                                           scale,
+                                           clip_before_nms,
+                                           clip_after_nms,
+                                           normalize,
+                                           box_size_scale,
+                                           box_coordinate_scale,
+                                           framework));
+
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(proposal)};
+    function = std::make_shared<ngraph::Function>(results, params, "proposal");
+}
+
+InferenceEngine::Blob::Ptr ProposalLayerTest::GenerateInput(const InferenceEngine::InputInfo &info) const {
+    InferenceEngine::Blob::Ptr blobPtr;
+
+    const std::string name = info.name();
+    if (name == "scores") {
+        blobPtr = FuncTestUtils::createAndFillBlobFloat(info.getTensorDesc(), 1, 0, 1000, 8234231);
+    } else if (name == "boxes") {
+        blobPtr = FuncTestUtils::createAndFillBlobFloatNormalDistribution(info.getTensorDesc(), 0.0f, 0.2f, 7235346);
+    } else if (name == "image_info") {
+        const float image_info[] = {225.0f, 225.0f, 1.0f};
+        blobPtr = FuncTestUtils::createAndFillBlobWithFloatArray(info.getTensorDesc(), image_info, 3);
+    }
+
+    return blobPtr;
+}
+
+// TODO: for validation, reference version is required (#28373)
+void ProposalLayerTest::Validate() {}
+
+TEST_P(ProposalLayerTest, CompareWithRefs) {
+    Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <ie_plugin_config.hpp>
+#include <ie_core.hpp>
+#include <functional>
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "single_layer_tests/reshape.hpp"
+
+namespace LayerTestsDefinitions {
+    std::string ReshapeLayerTest::getTestCaseName(testing::TestParamInfo<reshapeParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes, outFormShapes;
+    std::string targetDevice;
+    std::map<std::string, std::string> config;
+    bool specialZero;
+    std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice, config) = obj.param;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "specialZero=" << specialZero << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void ReshapeLayerTest::SetUp() {
+    InferenceEngine::SizeVector inputShapes, outFormShapes;
+    bool specialZero;
+    InferenceEngine::Precision netPrecision;
+    std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice, configuration) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    auto paramIn = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    auto constNode = std::make_shared<ngraph::opset1::Constant>(
+            ngraph::element::Type_t::i64, ngraph::Shape{outFormShapes.size()}, outFormShapes);
+    auto reshape = std::dynamic_pointer_cast<ngraph::opset1::Reshape>(
+            std::make_shared<ngraph::opset1::Reshape>(paramIn[0], constNode, specialZero));
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape)};
+    function = std::make_shared<ngraph::Function>(results, paramsIn, "Reshape");
+}
+
+TEST_P(ReshapeLayerTest, CompareWithRefsDynamicBath) {
+    Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
@@ -1,0 +1,70 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <functional>
+
+#include <ie_core.hpp>
+#include <ie_precision.hpp>
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/precision_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+
+#include "single_layer_tests/select.hpp"
+
+namespace LayerTestsDefinitions {
+    enum { CONDITION, THEN, ELSE, numOfInputs };
+
+    std::string SelectLayerTest::getTestCaseName(const testing::TestParamInfo<selectTestParams> &obj) {
+        std::vector<std::vector<size_t>> dataShapes(3);
+        InferenceEngine::Precision dataType;
+        ngraph::op::AutoBroadcastSpec broadcast;
+        std::string targetDevice;
+        std::tie(dataShapes, dataType, broadcast, targetDevice) = obj.param;
+        std::ostringstream result;
+        result << "COND=BOOL_" << CommonTestUtils::vec2str(dataShapes[CONDITION]);
+        result << "_THEN=" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[THEN]);
+        result << "_ELSE=" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[ELSE]);
+        result << "_" << broadcast.m_type;
+        result << "_targetDevice=" << targetDevice;
+        return result.str();
+    }
+
+    void SelectLayerTest::SetUp() {
+        SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
+
+        std::vector<std::vector<size_t>> inputShapes(numOfInputs);
+        InferenceEngine::Precision inputPrecision;
+        ngraph::op::AutoBroadcastSpec broadcast;
+        std::tie(inputShapes, inputPrecision, broadcast, targetDevice) = this->GetParam();
+
+        ngraph::ParameterVector paramNodesVector;
+        auto paramNode = std::make_shared<ngraph::opset1::Parameter>(ngraph::element::Type_t::boolean, ngraph::Shape(inputShapes[CONDITION]));
+        paramNodesVector.push_back(paramNode);
+        auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+        for (size_t i = 1; i < inputShapes.size(); i++) {
+            paramNode = std::make_shared<ngraph::opset1::Parameter>(inType, ngraph::Shape(inputShapes[i]));
+            paramNodesVector.push_back(paramNode);
+        }
+        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramNodesVector));
+
+        auto select = std::dynamic_pointer_cast<ngraph::opset1::Select>(ngraph::builder::makeSelect(paramOuts, broadcast));
+        ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(select)};
+        function = std::make_shared<ngraph::Function>(results, paramNodesVector, "select");
+    }
+
+    TEST_P(SelectLayerTest, CompareWithRefImpl) {
+        Run();
+
+        if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
+            PluginCache::get().reset();
+        }
+    }
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "single_layer_tests/softmax.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "ie_core.hpp"
+
+#include "ngraph/op/softmax.hpp"
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+namespace LayerTestsDefinitions {
+
+std::string SoftMaxLayerTest::getTestCaseName(testing::TestParamInfo<softMaxLayerTestParams> obj) {
+    InferenceEngine::Precision netPrecision, inputPrecision;
+    InferenceEngine::Layout inputLayout;
+    InferenceEngine::SizeVector inputShape;
+    size_t axis;
+    std::string targetDevice;
+    std::map<std::string, std::string> config;
+    std::tie(netPrecision, inputLayout, inputShape, axis, targetDevice, config) = obj.param;
+
+    std::ostringstream result;
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "inPRC=" << inputPrecision.name() << "_";
+    result << "inLayout=" << inputLayout << "_";
+    result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "axis=" << axis << "_";
+    result << "targetDevice=" << targetDevice;
+
+    return result.str();
+}
+
+void SoftMaxLayerTest::SetUp() {
+    InferenceEngine::SizeVector inputShape;
+    InferenceEngine::Precision netPrecision;
+    size_t axis;
+
+    std::tie(netPrecision, inLayout, inputShape, axis, targetDevice, configuration) = GetParam();
+    outLayout = inLayout;
+
+    const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+
+    const auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+
+    const auto paramOuts =
+        ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto softMax = std::make_shared<ngraph::opset1::Softmax>(paramOuts.at(0), axis);
+
+    const ngraph::ResultVector results {std::make_shared<ngraph::opset1::Result>(softMax)};
+
+    function = std::make_shared<ngraph::Function>(results, params, "softMax");
+}
+
+TEST_P(SoftMaxLayerTest, CompareWithRefs) {
+    Run();
+}
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_batch.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_batch.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2020 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -22,12 +22,11 @@ namespace LayerTestsDefinitions {
 
 std::string SpaceToBatchLayerTest::getTestCaseName(const testing::TestParamInfo<spaceToBatchParamsTuple> &obj) {
     std::vector<size_t> inShapes, blockShape, padsBegin, padsEnd;
-    InferenceEngine::Precision inPrc, netPrc;
+    InferenceEngine::Precision netPrc;
     std::string targetName;
-    std::tie(blockShape, padsBegin, padsEnd, inShapes, inPrc, netPrc, targetName) = obj.param;
+    std::tie(blockShape, padsBegin, padsEnd, inShapes, netPrc, targetName) = obj.param;
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inShapes) << "_";
-    result << "inPRC=" << inPrc.name() << "_";
     result << "netPRC=" << netPrc.name() << "_";
     result << "BS=" << CommonTestUtils::vec2str(blockShape) << "_";
     result << "PB=" << CommonTestUtils::vec2str(padsBegin) << "_";
@@ -38,8 +37,8 @@ std::string SpaceToBatchLayerTest::getTestCaseName(const testing::TestParamInfo<
 
 void SpaceToBatchLayerTest::SetUp() {
     std::vector<size_t> inputShape, blockShape, padsBegin, padsEnd;
-    std::tie(blockShape, padsBegin, padsEnd, inputShape, inputPrecision, netPrecision,
-             targetDevice) = this->GetParam();
+    InferenceEngine::Precision inputPrecision, netPrecision;
+    std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
@@ -47,11 +46,11 @@ void SpaceToBatchLayerTest::SetUp() {
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto s2b = ngraph::builder::makeSpaceToBatch(paramOuts[0], ngPrc, blockShape, padsBegin, padsEnd);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2b)};
-    fnPtr = std::make_shared<ngraph::Function>(results, params, "SpaceToBatch");
+    function = std::make_shared<ngraph::Function>(results, params, "SpaceToBatch");
 }
 
 TEST_P(SpaceToBatchLayerTest, CompareWithRefs) {
-    inferAndValidate();
-};
+    Run();
+}
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Intel Corporation
+// Copyright (C) 2019 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -23,25 +23,26 @@ namespace LayerTestsDefinitions {
 
 std::string SplitLayerTest::getTestCaseName(testing::TestParamInfo<splitParams> obj) {
     size_t numSplits, axis;
-    InferenceEngine::Precision inputPrecision, netPrecision;
+    InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes;
     std::string targetDevice;
-    std::tie(numSplits, axis, inputPrecision, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::tie(numSplits, axis, netPrecision, inputShapes, targetDevice) = obj.param;
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
     result << "numSplits=" << numSplits << "_";
     result << "axis=" << axis << "_";
     result << "IS";
-    result << "inPRC=" << inputPrecision.name() << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
     return result.str();
 }
 
 void SplitLayerTest::SetUp() {
+    SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
     size_t axis, numSplits;
     std::vector<size_t> inputShape;
-    std::tie(numSplits, axis, inputPrecision, netPrecision, inputShape, targetDevice) = this->GetParam();
+    InferenceEngine::Precision netPrecision;
+    std::tie(numSplits, axis, netPrecision, inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
     auto paramOuts = ngraph::helpers::convert2OutputVector(
@@ -52,11 +53,11 @@ void SplitLayerTest::SetUp() {
     for (int i = 0; i < numSplits; i++) {
         results.push_back(std::make_shared<ngraph::opset1::Result>(split));
     }
-    fnPtr = std::make_shared<ngraph::Function>(results, params, "split");
+    function = std::make_shared<ngraph::Function>(results, params, "split");
 }
 
 TEST_P(SplitLayerTest, CompareWithRefs) {
-    inferAndValidate();
+    Run();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <ie_core.hpp>
+#include <ngraph_functions/builders.hpp>
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/precision_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include "single_layer_tests/strided_slice.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string StridedSliceLayerTest::getTestCaseName(const testing::TestParamInfo<stridedSliceParamsTuple> &obj) {
+    InferenceEngine::SizeVector inputShape;
+    std::vector<int64_t> begin, end, stride;
+    std::vector<int64_t> begin_mask, new_axis_mask, end_mask, shrink_mask, ellipsis_mask;
+    InferenceEngine::Precision netPrc;
+    std::string targetName;
+    std::tie(inputShape, begin, end, stride, begin_mask, end_mask, new_axis_mask, shrink_mask, ellipsis_mask, netPrc,
+             targetName) = obj.param;
+    std::ostringstream result;
+    result << "inShape=" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "netPRC=" << netPrc.name() << "_";
+    result << "begin=" << CommonTestUtils::vec2str(begin) << "_";
+    result << "end=" << CommonTestUtils::vec2str(end) << "_";
+    result << "stride=" << CommonTestUtils::vec2str(stride) << "_";
+    result << "begin_m=" << CommonTestUtils::vec2str(begin_mask) << "_";
+    result << "end_m=" << CommonTestUtils::vec2str(end_mask) << "_";
+    result << "new_axis_m=" << CommonTestUtils::vec2str(new_axis_mask) << "_";
+    result << "shrink_m=" << CommonTestUtils::vec2str(shrink_mask) << "_";
+    result << "ellipsis_m=" << CommonTestUtils::vec2str(ellipsis_mask) << "_";
+    result << "targetDevice=" << targetName << "_";
+    return result.str();
+}
+
+void StridedSliceLayerTest::SetUp() {
+    InferenceEngine::SizeVector inputShape;
+    std::vector<int64_t> begin, end, stride;
+    std::vector<int64_t> begin_mask, end_mask, new_axis_mask, shrink_mask, ellipsis_mask;
+    InferenceEngine::Precision netPrecision;
+    std::tie(inputShape, begin, end, stride, begin_mask, end_mask, new_axis_mask, shrink_mask, ellipsis_mask,
+             netPrecision, targetDevice) = this->GetParam();
+
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+    auto ss = ngraph::builder::makeStridedSlice(paramOuts[0], begin, end, stride, ngPrc, begin_mask, end_mask,
+                                                new_axis_mask, shrink_mask, ellipsis_mask);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(ss)};
+    function = std::make_shared<ngraph::Function>(results, params, "StridedSlice");
+}
+
+TEST_P(StridedSliceLayerTest, CompareWithRefs) {
+    Run();
+}
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/ie_test_utils/common_test_utils/common_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/common_utils.hpp
@@ -15,9 +15,9 @@ namespace CommonTestUtils {
 template<typename vecElementType>
 inline std::string vec2str(const std::vector<vecElementType> &vec) {
     std::ostringstream result;
-    result << "(";
-    std::copy(vec.begin(), vec.end() - 1, std::ostream_iterator<size_t>(result, "."));
-    result << vec.back() << ")";
+    result << "_";
+    std::copy(vec.begin(), vec.end() - 1, std::ostream_iterator<size_t>(result, "_"));
+    result << vec.back() << "_";
     return result.str();
 }
 

--- a/inference-engine/tests/ie_test_utils/common_test_utils/test_constants.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/test_constants.hpp
@@ -14,6 +14,7 @@ const char DEVICE_FPGA[] = "FPGA";
 const char DEVICE_MYRIAD[] = "MYRIAD";
 const char DEVICE_MULTI[] = "MULTI";
 const char DEVICE_HETERO[] = "HETERO";
+const char DEVICE_PLAIDML[] = "PlaidML";
 
 #ifdef _WIN32
     #ifdef __MINGW32__

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -43,8 +43,6 @@ public:
     std::shared_ptr<ngraph::Function> fnPtr;
 
     void inline inferAndValidate() {
-        // Skip test according to plugin specific disabledTestPatterns() (if any)
-        SKIP_IF_CURRENT_TEST_IS_DISABLED()
         // Create CNNNetwork from ngrpah::Function
         InferenceEngine::CNNNetwork cnnNet(fnPtr);
         // Set target input Precisions for the network

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/plugin_cache.cpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/plugin_cache.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<InferenceEngine::Core> PluginCache::ie(const std::string &device
         std::cout << "'DISABLE_PLUGIN_CACHE' environment variable is set. New Core object will be created!"
                   << std::endl;
 #endif
-        return std::make_shared<InferenceEngine::Core>();
+        return std::make_shared<InferenceEngine::Core>("plaidml/bridge/openvino/plugins.xml");
     }
 #ifndef NDEBUG
     std::cout << "Access PluginCache ie core. IE Core use count: " << ie_core.use_count() << std::endl;
@@ -52,7 +52,7 @@ std::shared_ptr<InferenceEngine::Core> PluginCache::ie(const std::string &device
 #ifndef NDEBUG
         std::cout << "Created ie core." << std::endl;
 #endif
-        ie_core = std::make_shared<InferenceEngine::Core>();
+        ie_core = std::make_shared<InferenceEngine::Core>("plaidml/bridge/openvino/plugins.xml");
     }
     assert(0 != ie_core.use_count());
 

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/skip_tests_config.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/skip_tests_config.hpp
@@ -27,10 +27,3 @@ inline bool currentTestIsDisabled() {
 
 }  // namespace SkipTestsConfig
 }  // namespace FuncTestUtils
-
-#define SKIP_IF_CURRENT_TEST_IS_DISABLED()                              \
-{                                                                       \
-    if (FuncTestUtils::SkipTestsConfig::currentTestIsDisabled()) {      \
-        SKIP() << "Disabled test due to configuration" << std::endl;    \
-    }                                                                   \
-}


### PR DESCRIPTION
Backports the shared_tests from `master` branch to directly follow the 2020.2 tag. Also makes PlaidML-specific changes to simplify building with PlaidML.

The shared_tests have not yet been used (except for activations) and will probably have compilation errors without further modifications (again, except for activations); the work in this PR is intended to give us a basis for making those further changes.

Note that these changes are not compatible with a non-PlaidML backend and cannot land in main OpenVINO.