### PR TITLE
Backport many tests to 2020.2

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/add.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/add.hpp
@@ -18,12 +18,10 @@ namespace LayerTestsDefinitions {
     typedef std::tuple<
             InferenceEngine::Precision,         // Network precision
             std::vector<std::vector<size_t>>,   // Input shapes
-            std::string,                        // Device name
-            std::map<std::string, std::string>  // Config
+            std::string                        // Device name
             > addParams;
 
-class AddLayerTest : public testing::WithParamInterface<addParams>,
-                     public LayerTestsUtils::LayerTestsCommon {
+class AddLayerTest : public LayerTestsUtils::LayerTestsCommonClass<addParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<addParams> obj);
 protected:

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/batch_to_space.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/batch_to_space.hpp
@@ -21,8 +21,7 @@ using batchToSpaceParamsTuple = typename std::tuple<
         InferenceEngine::Precision,        // Network precision
         std::string>;                      // Device name>;
 
-class BatchToSpaceLayerTest : public testing::WithParamInterface<batchToSpaceParamsTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+class BatchToSpaceLayerTest : public LayerTestsUtils::LayerTestsCommonClass<batchToSpaceParamsTuple> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<batchToSpaceParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/concat.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/concat.hpp
@@ -22,8 +22,7 @@ using concatParamsTuple = typename std::tuple<
         InferenceEngine::Precision,        // Network precision
         std::string>;                      // Device name
 
-class ConcatLayerTest : public testing::WithParamInterface<concatParamsTuple>,
-                        public LayerTestsUtils::LayerTestsCommon {
+class ConcatLayerTest : public LayerTestsUtils::LayerTestsCommonClass<concatParamsTuple> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<concatParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution.hpp
@@ -26,13 +26,12 @@ typedef std::tuple<
         convSpecificParams,
         InferenceEngine::Precision,     // Net precision
         InferenceEngine::SizeVector,    // Input shapes
-        LayerTestsUtils::TargetDevice   // Device name
+        std::string   // Device name
 > convLayerTestParamsSet;
 namespace LayerTestsDefinitions {
 
 
-class ConvolutionLayerTest : public testing::WithParamInterface<convLayerTestParamsSet>,
-                             public LayerTestsUtils::LayerTestsCommon {
+class ConvolutionLayerTest : public LayerTestsUtils::LayerTestsCommonClass<convLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<convLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/convolution_backprop_data.hpp
@@ -26,13 +26,12 @@ typedef std::tuple<
         convBackpropDataSpecificParams,
         InferenceEngine::Precision,     // Net precision
         InferenceEngine::SizeVector,    // Input shapes
-        LayerTestsUtils::TargetDevice   // Device name
+        std::string   // Device name
 > convBackpropDataLayerTestParamsSet;
 namespace LayerTestsDefinitions {
 
 
-class ConvolutionBackpropDataLayerTest : public testing::WithParamInterface<convBackpropDataLayerTestParamsSet>,
-                                         public LayerTestsUtils::LayerTestsCommon {
+class ConvolutionBackpropDataLayerTest : public LayerTestsUtils::LayerTestsCommonClass<convBackpropDataLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<convBackpropDataLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/cum_sum.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/cum_sum.hpp
@@ -20,7 +20,7 @@ typedef std::tuple<
         bool,                        // Reverse
         std::string> cumSumParams;   // Device name
 
-class CumSumLayerTest : public testing::WithParamInterface<cumSumParams>, public LayerTestsUtils::LayerTestsCommon {
+class CumSumLayerTest : public LayerTestsUtils::LayerTestsCommonClass<cumSumParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<cumSumParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/eltwise.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/eltwise.hpp
@@ -40,8 +40,7 @@ typedef std::tuple<
     std::map<std::string, std::string>         // Additional network configuration
 > eltwiseLayerTestParamsSet;
 
-class EltwiseLayerTest : public testing::WithParamInterface<eltwiseLayerTestParamsSet>,
-    public LayerTestsUtils::LayerTestsCommon {
+class EltwiseLayerTest : public LayerTestsUtils::LayerTestsCommonClass<eltwiseLayerTestParamsSet> {
 protected:
     void SetUp() override;
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/extract_image_patches.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/extract_image_patches.hpp
@@ -20,10 +20,9 @@ using extractImagePatchesTuple = typename std::tuple<
         std::vector<size_t>,               // rates
         ngraph::op::PadType,               // pad type
         InferenceEngine::Precision,        // Network precision
-        LayerTestsUtils::TargetDevice>;                      // Device name
+        std::string>;                      // Device name
 
-class ExtractImagePatchesTest : public testing::WithParamInterface<extractImagePatchesTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+class ExtractImagePatchesTest : public LayerTestsUtils::LayerTestsCommonClass<extractImagePatchesTuple> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/fake_quantize.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/fake_quantize.hpp
@@ -21,13 +21,12 @@ typedef std::tuple<
         fqSpecificParams,
         InferenceEngine::Precision,   // Net precision
         InferenceEngine::SizeVector,  // Input shapes
-        LayerTestsUtils::TargetDevice // Device name
+        std::string // Device name
 > fqLayerTestParamsSet;
 namespace LayerTestsDefinitions {
 
 
-class FakeQuantizeLayerTest : public testing::WithParamInterface<fqLayerTestParamsSet>,
-                              public LayerTestsUtils::LayerTestsCommon {
+class FakeQuantizeLayerTest : public LayerTestsUtils::LayerTestsCommonClass<fqLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<fqLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution.hpp
@@ -26,12 +26,11 @@ typedef std::tuple<
         groupConvSpecificParams,
         InferenceEngine::Precision,
         InferenceEngine::SizeVector,
-        LayerTestsUtils::TargetDevice> groupConvLayerTestParamsSet;
+        std::string> groupConvLayerTestParamsSet;
 
 namespace LayerTestsDefinitions {
 
-class GroupConvolutionLayerTest : public testing::WithParamInterface<groupConvLayerTestParamsSet>,
-                                  public LayerTestsUtils::LayerTestsCommon {
+class GroupConvolutionLayerTest : public LayerTestsUtils::LayerTestsCommonClass<groupConvLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution_backprop_data.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/group_convolution_backprop_data.hpp
@@ -30,8 +30,7 @@ typedef std::tuple<
 
 namespace LayerTestsDefinitions {
 
-class GroupConvBackpropDataLayerTest : public testing::WithParamInterface<groupConvBackpropDataLayerTestParamsSet>,
-                                       public LayerTestsUtils::LayerTestsCommon {
+class GroupConvBackpropDataLayerTest : public LayerTestsUtils::LayerTestsCommonClass<groupConvBackpropDataLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<groupConvBackpropDataLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/lrn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/lrn.hpp
@@ -28,8 +28,7 @@ typedef std::tuple<
 > lrnLayerTestParamsSet;
 
 class LrnLayerTest
-        : public testing::WithParamInterface<lrnLayerTestParamsSet>,
-          public LayerTestsUtils::LayerTestsCommon {
+        : public LayerTestsUtils::LayerTestsCommonClass<lrnLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<lrnLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/multiply.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/multiply.hpp
@@ -19,9 +19,7 @@ using MultiplyParamsTuple = typename std::tuple<
         InferenceEngine::Precision,       //Network precision
         std::string>;                     //Device name
 
-class MultiplyLayerTest:
-        public testing::WithParamInterface<MultiplyParamsTuple>,
-        public LayerTestsUtils::LayerTestsCommon{
+class MultiplyLayerTest : public LayerTestsUtils::LayerTestsCommonClass<MultiplyParamsTuple>{
 public:
     std::shared_ptr<ngraph::Function> fn;
     static std::string getTestCaseName(const testing::TestParamInfo<MultiplyParamsTuple> &obj);

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
@@ -20,7 +20,7 @@ typedef std::tuple<
         double,                      // Epsilon
         std::string> mvnParams;      // Device name
 
-class MvnLayerTest : public testing::WithParamInterface<mvnParams>, public LayerTestsUtils::LayerTestsCommon {
+class MvnLayerTest : public LayerTestsUtils::LayerTestsCommonClass<mvnParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<mvnParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/pooling.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/pooling.hpp
@@ -34,8 +34,7 @@ typedef std::tuple<
         std::string                     // Device name
 > poolLayerTestParamsSet;
 
-class PoolingLayerTest : public testing::WithParamInterface<poolLayerTestParamsSet>,
-                         public LayerTestsUtils::LayerTestsCommon {
+class PoolingLayerTest : public LayerTestsUtils::LayerTestsCommonClass<poolLayerTestParamsSet> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<poolLayerTestParamsSet> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reshape.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reshape.hpp
@@ -19,12 +19,10 @@ typedef std::tuple<
         InferenceEngine::Precision,         // Network precision
         std::vector<size_t>,                // Input shapes
         std::vector<size_t>,                // OutForm Shapes
-        std::string,                        // Device name
-        std::map<std::string, std::string>  // Config
+        std::string                         // Device name
 > reshapeParams;
 
-class ReshapeLayerTest : public testing::WithParamInterface<reshapeParams>,
-                         public LayerTestsUtils::LayerTestsCommon {
+class ReshapeLayerTest : public LayerTestsUtils::LayerTestsCommonClass<reshapeParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<reshapeParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/select.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/select.hpp
@@ -18,7 +18,7 @@ typedef std::tuple<
         ngraph::op::AutoBroadcastSpec,     // broadcast
         std::string> selectTestParams;     // device name
 
-class SelectLayerTest : public testing::WithParamInterface<selectTestParams>, public LayerTestsUtils::LayerTestsCommon {
+class SelectLayerTest : public LayerTestsUtils::LayerTestsCommonClass<selectTestParams> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo <selectTestParams> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/softmax.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/softmax.hpp
@@ -22,12 +22,10 @@ using softMaxLayerTestParams = std::tuple<
         InferenceEngine::Layout,            // inputLayout
         InferenceEngine::SizeVector,        // inputShape
         size_t,                             // axis
-        std::string,                        // targetDevice
-        std::map<std::string, std::string>  // config
+        std::string                         // targetDevice
 >;
 
-class SoftMaxLayerTest : public testing::WithParamInterface<softMaxLayerTestParams>,
-                         public LayerTestsUtils::LayerTestsCommon {
+class SoftMaxLayerTest : public LayerTestsUtils::LayerTestsCommonClass<softMaxLayerTestParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<softMaxLayerTestParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_batch.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_batch.hpp
@@ -21,8 +21,7 @@ using spaceToBatchParamsTuple = typename std::tuple<
         InferenceEngine::Precision,        // Network precision
         std::string>;                      // Device name>;
 
-class SpaceToBatchLayerTest : public testing::WithParamInterface<spaceToBatchParamsTuple>,
-                              public LayerTestsUtils::LayerTestsCommon {
+class SpaceToBatchLayerTest : public LayerTestsUtils::LayerTestsCommonClass<spaceToBatchParamsTuple> {
 public:
     static std::string getTestCaseName(const testing::TestParamInfo<spaceToBatchParamsTuple> &obj);
 

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/split.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/split.hpp
@@ -22,8 +22,7 @@ typedef std::tuple<
         std::string                     // Target device name
 > splitParams;
 
-class SplitLayerTest : public testing::WithParamInterface<splitParams>,
-                       public LayerTestsUtils::LayerTestsCommon {
+class SplitLayerTest : public LayerTestsUtils::LayerTestsCommonClass<splitParams> {
 public:
     static std::string getTestCaseName(testing::TestParamInfo<splitParams> obj);
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/add.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/add.cpp
@@ -15,23 +15,24 @@
 #include "single_layer_tests/add.hpp"
 
 namespace LayerTestsDefinitions {
-    std::string AddLayerTest::getTestCaseName(testing::TestParamInfo<addParams> obj) {
+
+std::string AddLayerTest::getTestCaseName(testing::TestParamInfo<addParams> obj) {
     InferenceEngine::Precision netPrecision;
     std::vector<InferenceEngine::SizeVector> inputShapes;
     std::string targetDevice;
     std::map<std::string, std::string> config;
-    std::tie(netPrecision, inputShapes, targetDevice, config) = obj.param;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
 void AddLayerTest::SetUp() {
     std::vector<InferenceEngine::SizeVector> inputShapes;
     InferenceEngine::Precision netPrecision;
-    std::tie(netPrecision, inputShapes, targetDevice, configuration) = this->GetParam();
+    std::tie(netPrecision, inputShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
     auto paramIn = ngraph::helpers::convert2OutputVector(
@@ -39,10 +40,10 @@ void AddLayerTest::SetUp() {
     IE_ASSERT(paramIn.size() == 2);
     auto add = std::make_shared<ngraph::opset1::Add>(paramsIn[0], paramsIn[1]);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(add)};
-    function = std::make_shared<ngraph::Function>(results, paramsIn, "Add");
+    fnPtr = std::make_shared<ngraph::Function>(results, paramsIn, "Add");
 }
 
 TEST_P(AddLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
@@ -26,12 +26,12 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
     std::string targetName;
     std::tie(blockShape, cropsBegin, cropsEnd, inShapes, netPrc, targetName) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inShapes) << "_";
-    result << "netPRC=" << netPrc.name() << "_";
-    result << "BS=" << CommonTestUtils::vec2str(blockShape) << "_";
-    result << "CB=" << CommonTestUtils::vec2str(cropsBegin) << "_";
-    result << "CE=" << CommonTestUtils::vec2str(cropsEnd) << "_";
-    result << "targetDevice=" << targetName << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inShapes) << "_";
+    result << "netPRC_" << netPrc.name() << "_";
+    result << "BS_" << CommonTestUtils::vec2str(blockShape) << "_";
+    result << "CB_" << CommonTestUtils::vec2str(cropsBegin) << "_";
+    result << "CE_" << CommonTestUtils::vec2str(cropsEnd) << "_";
+    result << "targetDevice_" << targetName << "_";
     return result.str();
 }
 
@@ -45,11 +45,11 @@ void BatchToSpaceLayerTest::SetUp() {
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto b2s = ngraph::builder::makeBatchToSpace(paramOuts[0], ngPrc, blockShape, cropsBegin, cropsEnd);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(b2s)};
-    function = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "BatchToSpace");
 }
 
 TEST_P(BatchToSpaceLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
@@ -27,10 +27,10 @@ std::string ConcatLayerTest::getTestCaseName(const testing::TestParamInfo<concat
     std::string targetName;
     std::tie(axis, inputShapes, netPrecision, targetName) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "axis=" << axis << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetName << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "axis_" << axis << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetName << "_";
     return result.str();
 }
 
@@ -45,11 +45,11 @@ void ConcatLayerTest::SetUp() {
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto concat = std::make_shared<ngraph::opset1::Concat>(paramOuts, axis);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(concat)};
-    function = std::make_shared<ngraph::Function>(results, params, "concat");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "concat");
 }
 
 
 TEST_P(ConcatLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 };
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution.cpp
@@ -33,16 +33,16 @@ std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLay
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convParams;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
     result << "K" << CommonTestUtils::vec2str(kernel) << "_";
     result << "S" << CommonTestUtils::vec2str(stride) << "_";
     result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
-    result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
-    result << "O=" << convOutChannels << "_";
-    result << "AP=" << padType << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "D_" << CommonTestUtils::vec2str(dilation) << "_";
+    result << "O_" << convOutChannels << "_";
+    result << "AP_" << padType << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -64,10 +64,10 @@ void ConvolutionLayerTest::SetUp() {
             ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(conv)};
-    function = std::make_shared<ngraph::Function>(results, params, "convolution");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "convolution");
 }
 
 TEST_P(ConvolutionLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
@@ -33,16 +33,16 @@ std::string ConvolutionBackpropDataLayerTest::getTestCaseName(testing::TestParam
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType) = convBackpropDataParams;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
     result << "K" << CommonTestUtils::vec2str(kernel) << "_";
     result << "S" << CommonTestUtils::vec2str(stride) << "_";
     result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
-    result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
-    result << "O=" << convOutChannels << "_";
-    result << "AP=" << padType << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "D_" << CommonTestUtils::vec2str(dilation) << "_";
+    result << "O_" << convOutChannels << "_";
+    result << "AP_" << padType << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -64,10 +64,10 @@ void ConvolutionBackpropDataLayerTest::SetUp() {
             ngraph::builder::makeConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
                                                          padEnd, dilation, padType, convOutChannels));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(convBackpropData)};
-    function = std::make_shared<ngraph::Function>(results, params, "convolutionBackpropData");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "convolutionBackpropData");
 }
 
 TEST_P(ConvolutionBackpropDataLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/cum_sum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/cum_sum.cpp
@@ -28,12 +28,12 @@ std::string CumSumLayerTest::getTestCaseName(testing::TestParamInfo<cumSumParams
     std::tie(inputShapes, inputPrecision, axis, exclusive, reverse, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "Precision=" << inputPrecision.name() << "_";
-    result << "Axis=" << axis << "_";
-    result << "Exclusive=" << (exclusive ? "TRUE" : "FALSE") << "_";
-    result << "Reverse=" << (reverse ? "TRUE" : "FALSE") << "_";
-    result << "TargetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "Precision_" << inputPrecision.name() << "_";
+    result << "Axis_" << axis << "_";
+    result << "Exclusive_" << (exclusive ? "TRUE" : "FALSE") << "_";
+    result << "Reverse_" << (reverse ? "TRUE" : "FALSE") << "_";
+    result << "TargetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -54,11 +54,11 @@ void CumSumLayerTest::SetUp() {
     auto cumSum = std::dynamic_pointer_cast<ngraph::op::CumSum>(ngraph::builder::makeCumSum(paramOuts[0], axisNode, exclusive, reverse));
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(cumSum)};
-    function = std::make_shared<ngraph::Function>(results, paramVector, "cumsum");
+    fnPtr = std::make_shared<ngraph::Function>(results, paramVector, "cumsum");
 }
 
 TEST_P(CumSumLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
@@ -27,17 +27,17 @@ std::string EltwiseLayerTest::getTestCaseName(testing::TestParamInfo<eltwiseLaye
     InputLayerType secondary_input_type;
     InferenceEngine::Precision prec;
     InferenceEngine::SizeVector vec;
-    LayerTestsUtils::TargetDevice dev;
+    std::string dev;
     std::map<std::string, std::string> additional_config;
     std::tie(op, primary_input_idx, secondary_input_type, prec, vec, dev, additional_config) = obj.param;
 
     std::ostringstream result;
-    result << "operation=" << EltwiseOpType_to_string(op) << "_";
-    result << "netPRC=" << prec.name() << "_";
-    result << "primaryInputIdx=" << primary_input_idx << "_";
-    result << "secondaryInputType=" << InputLayerType_to_string(secondary_input_type) << "_";
-    result << "inputShapes=" << CommonTestUtils::vec2str(vec) << "_";
-    result << "targetDevice=" << dev;
+    result << "operation_" << EltwiseOpType_to_string(op) << "_";
+    result << "netPRC_" << prec.name() << "_";
+    result << "primaryInputIdx_" << primary_input_idx << "_";
+    result << "secondaryInputType_" << InputLayerType_to_string(secondary_input_type) << "_";
+    result << "inputShapes_" << CommonTestUtils::vec2str(vec) << "_";
+    result << "targetDevice_" << dev;
     return result.str();
 }
 
@@ -50,7 +50,6 @@ void EltwiseLayerTest::SetUp() {
     ngraph::ParameterVector parameter_inputs;
     std::map<std::string, std::string> additional_config;
     std::tie(op, primary_input_idx, secondary_input_type, netPrecision, inputShape, targetDevice, additional_config) = this->GetParam();
-    configuration.insert(additional_config.begin(), additional_config.end());
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
     std::shared_ptr<ngraph::Node> input0_node;
@@ -123,7 +122,7 @@ void EltwiseLayerTest::SetUp() {
         ASSERT_EQ(std::string("Unknown Eltwise operation type: ") + EltwiseOpType_to_string(op), "");
         break;
     }
-    function = std::make_shared<ngraph::Function>(ngraph_op, parameter_inputs, "Eltwise_op");
+    fnPtr = std::make_shared<ngraph::Function>(ngraph_op, parameter_inputs, "Eltwise_op");
 }
 
 const char* EltwiseTestNamespace::InputLayerType_to_string(InputLayerType lt) {
@@ -151,5 +150,5 @@ const char* EltwiseTestNamespace::EltwiseOpType_to_string(EltwiseOpType eOp) {
 }
 
 TEST_P(EltwiseLayerTest, basic) {
-    Run();
+    inferAndValidate();
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
@@ -24,13 +24,13 @@ std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInf
     std::string targetName;
     std::tie(inputShape, kernel, strides, rates, pad_type, netPrc, targetName) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
-    result << "netPRC=" << netPrc.name() << "_";
-    result << "K=" << CommonTestUtils::vec2str(kernel) << "_";
-    result << "S=" << CommonTestUtils::vec2str(strides) << "_";
-    result << "R=" << CommonTestUtils::vec2str(rates) << "_";
-    result << "P=" << pad_type << "_";
-    result << "targetDevice=" << targetName;
+    result << "IS_" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "netPRC_" << netPrc.name() << "_";
+    result << "K_" << CommonTestUtils::vec2str(kernel) << "_";
+    result << "S_" << CommonTestUtils::vec2str(strides) << "_";
+    result << "R_" << CommonTestUtils::vec2str(rates) << "_";
+    result << "P_" << pad_type << "_";
+    result << "targetDevice_" << targetName;
     return result.str();
 }
 
@@ -47,11 +47,11 @@ void ExtractImagePatchesTest::SetUp() {
     auto extImgPatches = std::make_shared<ngraph::opset3::ExtractImagePatches>(
         inputNode, ngraph::Shape(kernel), ngraph::Strides(strides), ngraph::Shape(rates), pad_type);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(extImgPatches)};
-    function = std::make_shared<ngraph::Function>(results, params, "ExtractImagePatches");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "ExtractImagePatches");
 }
 
 TEST_P(ExtractImagePatchesTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
@@ -31,11 +31,11 @@ std::string FakeQuantizeLayerTest::getTestCaseName(testing::TestParamInfo<fqLaye
     std::tie(levels, constShape) = fqParams;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "CS=" << CommonTestUtils::vec2str(constShape) << "_";
-    result << "LEVELS=" << levels << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "CS_" << CommonTestUtils::vec2str(constShape) << "_";
+    result << "LEVELS_" << levels << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -55,10 +55,10 @@ void FakeQuantizeLayerTest::SetUp() {
     auto fq = std::dynamic_pointer_cast<ngraph::opset1::FakeQuantize>(ngraph::builder::makeFakeQuantize(paramOuts[0], ngPrc, levels, constShape));
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(fq)};
-    function = std::make_shared<ngraph::Function>(results, params, "fakeQuantize");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "fakeQuantize");
 }
 
 TEST_P(FakeQuantizeLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
@@ -33,17 +33,17 @@ std::string GroupConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<gr
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvParams;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
     result << "K" << CommonTestUtils::vec2str(kernel) << "_";
     result << "S" << CommonTestUtils::vec2str(stride) << "_";
     result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
-    result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
-    result << "O=" << convOutChannels << "_";
-    result << "G=" << numGroups << "_";
-    result << "AP=" << padType << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "D_" << CommonTestUtils::vec2str(dilation) << "_";
+    result << "O_" << convOutChannels << "_";
+    result << "G_" << numGroups << "_";
+    result << "AP_" << padType << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -65,10 +65,10 @@ void GroupConvolutionLayerTest::SetUp() {
             ngraph::builder::makeGroupConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels, numGroups));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConv)};
-    function = std::make_shared<ngraph::Function>(results, params, "groupConvolution");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "groupConvolution");
 }
 
 TEST_P(GroupConvolutionLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution_backprop_data.cpp
@@ -33,17 +33,17 @@ std::string GroupConvBackpropDataLayerTest::getTestCaseName(testing::TestParamIn
     std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, numGroups, padType) = groupConvBackpropDataParams;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
     result << "K" << CommonTestUtils::vec2str(kernel) << "_";
     result << "S" << CommonTestUtils::vec2str(stride) << "_";
     result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
-    result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
-    result << "O=" << convOutChannels << "_";
-    result << "G=" << numGroups << "_";
-    result << "AP=" << padType << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "D_" << CommonTestUtils::vec2str(dilation) << "_";
+    result << "O_" << convOutChannels << "_";
+    result << "G_" << numGroups << "_";
+    result << "AP_" << padType << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -65,10 +65,10 @@ void GroupConvBackpropDataLayerTest::SetUp() {
             ngraph::builder::makeGroupConvolutionBackpropData(paramOuts[0], ngPrc, kernel, stride, padBegin,
                                              padEnd, dilation, padType, convOutChannels, numGroups));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(groupConvBackpropData)};
-    function = std::make_shared<ngraph::Function>(results, params, "GroupConvolutionBackpropData");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "GroupConvolutionBackpropData");
 }
 
 TEST_P(GroupConvBackpropDataLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
@@ -22,13 +22,13 @@ std::string LrnLayerTest::getTestCaseName(testing::TestParamInfo<lrnLayerTestPar
 
     std::ostringstream result;
     const char separator = '_';
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << separator;
-    result << "Alpha=" << alpha << separator;
-    result << "Beta=" << beta << separator;
-    result << "Bias=" << bias << separator;
-    result << "Size=" << size << separator;
-    result << "netPRC=" << netPrecision.name() << separator;
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "Alpha__in_ppm__" << alpha * 10e6 << separator;
+    result << "Beta_" << beta << separator;
+    result << "Bias_" << bias << separator;
+    result << "Size_" << size << separator;
+    result << "netPRC_" << netPrecision.name() << separator;
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }
@@ -46,10 +46,10 @@ void LrnLayerTest::SetUp() {
 
     auto lrn = std::make_shared<ngraph::opset1::LRN>(paramIn[0], alpha, beta, bias, size);
     ngraph::ResultVector results {std::make_shared<ngraph::opset1::Result>(lrn)};
-    function = std::make_shared<ngraph::Function>(results, params, "lrn");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "lrn");
 }
 
 TEST_P(LrnLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/multiply.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/multiply.cpp
@@ -24,9 +24,9 @@ namespace LayerTestsDefinitions {
         std::tie(inputShapes, netPrecision, targetName) = obj.param;
         std::ostringstream results;
 
-        results << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-        results << "netPRC=" << netPrecision.name() << "_";
-        results << "targetDevice=" << targetName << "_";
+        results << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+        results << "netPRC_" << netPrecision.name() << "_";
+        results << "targetDevice_" << targetName << "_";
         return results.str();
     }
 
@@ -40,10 +40,10 @@ namespace LayerTestsDefinitions {
         auto input = ngraph::builder::makeParams(ngPrc, {shape_input});
         auto const_mul = ngraph::builder::makeConstant(ngPrc, ngraph::Shape{1}, std::vector<float>{-1.0f});
         auto mul = std::make_shared<ngraph::opset1::Multiply>(input[0], const_mul);
-        function = std::make_shared<ngraph::Function>(mul, input, "multiply");
+        fnPtr = std::make_shared<ngraph::Function>(mul, input, "multiply");
     }
 
     TEST_P(MultiplyLayerTest, CompareWithRefs){
-        Run();
+        inferAndValidate();
     };
 } // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
@@ -29,12 +29,12 @@ std::string MvnLayerTest::getTestCaseName(testing::TestParamInfo<mvnParams> obj)
     std::string targetDevice;
     std::tie(inputShapes, inputPrecision, acrossChannels, normalizeVariance, eps, targetDevice) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "Precision=" << inputPrecision.name() << "_";
-    result << "AcrossChannels=" << (acrossChannels ? "TRUE" : "FALSE") << "_";
-    result << "NormalizeVariance=" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
-    result << "Epsilon=" << eps << "_";
-    result << "TargetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "Precision_" << inputPrecision.name() << "_";
+    result << "AcrossChannels_" << (acrossChannels ? "TRUE" : "FALSE") << "_";
+    result << "NormalizeVariance_" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
+    result << "Epsilon_" << eps << "_";
+    result << "TargetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -49,11 +49,11 @@ void MvnLayerTest::SetUp() {
     auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
     auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(paramOuts[0], acrossChanels, normalizeVariance, eps));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(mvn)};
-    function = std::make_shared<ngraph::Function>(results, param, "mvn");
+    fnPtr = std::make_shared<ngraph::Function>(results, param, "mvn");
 }
 
 TEST_P(MvnLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 };
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
@@ -37,14 +37,14 @@ std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTe
     std::tie(poolType, kernel, stride, padBegin, padEnd, roundingType, padType, excludePad) = poolParams;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
     switch (poolType) {
         case ngraph::helpers::PoolingTypes::MAX:
             result << "MaxPool_";
             break;
         case ngraph::helpers::PoolingTypes::AVG:
             result << "AvgPool_";
-            result << "ExcludePad=" << excludePad << "_";
+            result << "ExcludePad_" << excludePad << "_";
             break;
     }
     result << "K" << CommonTestUtils::vec2str(kernel) << "_";
@@ -52,11 +52,11 @@ std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTe
     result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
     result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
     if (padType == ngraph::op::PadType::EXPLICIT) {
-        result << "Rounding=" << roundingType << "_";
+        result << "Rounding_" << roundingType << "_";
     }
-    result << "AutoPad=" << padType << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "AutoPad_" << padType << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -92,10 +92,10 @@ void PoolingLayerTest::SetUp() {
     }
 
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(pooling)};
-    function = std::make_shared<ngraph::Function>(results, params, "pooling");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "pooling");
 }
 
 TEST_P(PoolingLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
@@ -20,14 +20,13 @@ namespace LayerTestsDefinitions {
     InferenceEngine::Precision netPrecision;
     InferenceEngine::SizeVector inputShapes, outFormShapes;
     std::string targetDevice;
-    std::map<std::string, std::string> config;
     bool specialZero;
-    std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice, config) = obj.param;
+    std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "specialZero=" << specialZero << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "specialZero_" << specialZero << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
@@ -35,7 +34,7 @@ void ReshapeLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShapes, outFormShapes;
     bool specialZero;
     InferenceEngine::Precision netPrecision;
-    std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice, configuration) = this->GetParam();
+    std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
     auto paramIn = ngraph::helpers::convert2OutputVector(
@@ -45,10 +44,10 @@ void ReshapeLayerTest::SetUp() {
     auto reshape = std::dynamic_pointer_cast<ngraph::opset1::Reshape>(
             std::make_shared<ngraph::opset1::Reshape>(paramIn[0], constNode, specialZero));
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(reshape)};
-    function = std::make_shared<ngraph::Function>(results, paramsIn, "Reshape");
+    fnPtr = std::make_shared<ngraph::Function>(results, paramsIn, "Reshape");
 }
 
 TEST_P(ReshapeLayerTest, CompareWithRefsDynamicBath) {
-    Run();
+    inferAndValidate();
 }
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
@@ -28,11 +28,11 @@ namespace LayerTestsDefinitions {
         std::string targetDevice;
         std::tie(dataShapes, dataType, broadcast, targetDevice) = obj.param;
         std::ostringstream result;
-        result << "COND=BOOL_" << CommonTestUtils::vec2str(dataShapes[CONDITION]);
-        result << "_THEN=" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[THEN]);
-        result << "_ELSE=" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[ELSE]);
+        result << "COND_BOOL_" << CommonTestUtils::vec2str(dataShapes[CONDITION]);
+        result << "_THEN_" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[THEN]);
+        result << "_ELSE_" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[ELSE]);
         result << "_" << broadcast.m_type;
-        result << "_targetDevice=" << targetDevice;
+        result << "_targetDevice_" << targetDevice;
         return result.str();
     }
 
@@ -56,11 +56,11 @@ namespace LayerTestsDefinitions {
 
         auto select = std::dynamic_pointer_cast<ngraph::opset1::Select>(ngraph::builder::makeSelect(paramOuts, broadcast));
         ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(select)};
-        function = std::make_shared<ngraph::Function>(results, paramNodesVector, "select");
+        fnPtr = std::make_shared<ngraph::Function>(results, paramNodesVector, "select");
     }
 
     TEST_P(SelectLayerTest, CompareWithRefImpl) {
-        Run();
+        inferAndValidate();
 
         if (targetDevice == std::string{CommonTestUtils::DEVICE_GPU}) {
             PluginCache::get().reset();

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
@@ -26,27 +26,26 @@ std::string SoftMaxLayerTest::getTestCaseName(testing::TestParamInfo<softMaxLaye
     InferenceEngine::SizeVector inputShape;
     size_t axis;
     std::string targetDevice;
-    std::map<std::string, std::string> config;
-    std::tie(netPrecision, inputLayout, inputShape, axis, targetDevice, config) = obj.param;
+    std::tie(netPrecision, inputLayout, inputShape, axis, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "inPRC=" << inputPrecision.name() << "_";
-    result << "inLayout=" << inputLayout << "_";
-    result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
-    result << "axis=" << axis << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "inPRC_" << inputPrecision.name() << "_";
+    result << "inLayout_" << inputLayout << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "axis_" << axis << "_";
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }
 
 void SoftMaxLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShape;
+    InferenceEngine::Layout inLayout;
     InferenceEngine::Precision netPrecision;
     size_t axis;
 
-    std::tie(netPrecision, inLayout, inputShape, axis, targetDevice, configuration) = GetParam();
-    outLayout = inLayout;
+    std::tie(netPrecision, inLayout, inputShape, axis, targetDevice) = GetParam();
 
     const auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 
@@ -59,11 +58,11 @@ void SoftMaxLayerTest::SetUp() {
 
     const ngraph::ResultVector results {std::make_shared<ngraph::opset1::Result>(softMax)};
 
-    function = std::make_shared<ngraph::Function>(results, params, "softMax");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "softMax");
 }
 
 TEST_P(SoftMaxLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_batch.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_batch.cpp
@@ -26,12 +26,12 @@ std::string SpaceToBatchLayerTest::getTestCaseName(const testing::TestParamInfo<
     std::string targetName;
     std::tie(blockShape, padsBegin, padsEnd, inShapes, netPrc, targetName) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inShapes) << "_";
-    result << "netPRC=" << netPrc.name() << "_";
-    result << "BS=" << CommonTestUtils::vec2str(blockShape) << "_";
-    result << "PB=" << CommonTestUtils::vec2str(padsBegin) << "_";
-    result << "PE=" << CommonTestUtils::vec2str(padsEnd) << "_";
-    result << "targetDevice=" << targetName << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inShapes) << "_";
+    result << "netPRC_" << netPrc.name() << "_";
+    result << "BS_" << CommonTestUtils::vec2str(blockShape) << "_";
+    result << "PB_" << CommonTestUtils::vec2str(padsBegin) << "_";
+    result << "PE_" << CommonTestUtils::vec2str(padsEnd) << "_";
+    result << "targetDevice_" << targetName << "_";
     return result.str();
 }
 
@@ -46,11 +46,11 @@ void SpaceToBatchLayerTest::SetUp() {
             ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
     auto s2b = ngraph::builder::makeSpaceToBatch(paramOuts[0], ngPrc, blockShape, padsBegin, padsEnd);
     ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2b)};
-    function = std::make_shared<ngraph::Function>(results, params, "SpaceToBatch");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "SpaceToBatch");
 }
 
 TEST_P(SpaceToBatchLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 }
 
 }  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
@@ -28,17 +28,17 @@ std::string SplitLayerTest::getTestCaseName(testing::TestParamInfo<splitParams> 
     std::string targetDevice;
     std::tie(numSplits, axis, netPrecision, inputShapes, targetDevice) = obj.param;
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "numSplits=" << numSplits << "_";
-    result << "axis=" << axis << "_";
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "numSplits_" << numSplits << "_";
+    result << "axis_" << axis << "_";
     result << "IS";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 
 void SplitLayerTest::SetUp() {
-    SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
+    // SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
     size_t axis, numSplits;
     std::vector<size_t> inputShape;
     InferenceEngine::Precision netPrecision;
@@ -53,11 +53,11 @@ void SplitLayerTest::SetUp() {
     for (int i = 0; i < numSplits; i++) {
         results.push_back(std::make_shared<ngraph::opset1::Result>(split));
     }
-    function = std::make_shared<ngraph::Function>(results, params, "split");
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "split");
 }
 
 TEST_P(SplitLayerTest, CompareWithRefs) {
-    Run();
+    inferAndValidate();
 };
 
 }  // namespace LayerTestsDefinitions


### PR DESCRIPTION
Revert details of tests to be compatible with 2020.2 OpenVINO. See also #1 if context is needed.