### PR TITLE
Fix precision parameters

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/add.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/add.cpp
@@ -31,7 +31,6 @@ std::string AddLayerTest::getTestCaseName(testing::TestParamInfo<addParams> obj)
 
 void AddLayerTest::SetUp() {
     std::vector<InferenceEngine::SizeVector> inputShapes;
-    InferenceEngine::Precision netPrecision;
     std::tie(netPrecision, inputShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
@@ -37,7 +37,6 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
 
 void BatchToSpaceLayerTest::SetUp() {
     std::vector<size_t> inputShape, blockShape, cropsBegin, cropsEnd;
-    InferenceEngine::Precision netPrecision;
     std::tie(blockShape, cropsBegin, cropsEnd, inputShape, netPrecision, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
@@ -37,7 +37,6 @@ std::string ConcatLayerTest::getTestCaseName(const testing::TestParamInfo<concat
 void ConcatLayerTest::SetUp() {
     int axis;
     std::vector<std::vector<size_t>> inputShape;
-    InferenceEngine::Precision netPrecision;
     std::tie(axis, inputShape, netPrecision, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, inputShape);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution.cpp
@@ -49,7 +49,6 @@ std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLay
 void ConvolutionLayerTest::SetUp() {
     convSpecificParams convParams;
     std::vector<size_t> inputShape;
-    auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(convParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
@@ -49,7 +49,6 @@ std::string ConvolutionBackpropDataLayerTest::getTestCaseName(testing::TestParam
 void ConvolutionBackpropDataLayerTest::SetUp() {
     convBackpropDataSpecificParams convBackpropDataParams;
     std::vector<size_t> inputShape;
-    auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(convBackpropDataParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/ctc_greedy_decoder.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/ctc_greedy_decoder.cpp
@@ -122,7 +122,6 @@ std::vector<std::vector<std::uint8_t>> CTCGreedyDecoderLayerTest::CalculateRefs(
 }
 
 void CTCGreedyDecoderLayerTest::SetUp() {
-    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(netPrecision, inputShapes, mergeRepeated, targetDevice) = GetParam();
     sequenceLengths = { inputShapes.at(0), inputShapes.at(1) };
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/cum_sum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/cum_sum.cpp
@@ -39,7 +39,6 @@ std::string CumSumLayerTest::getTestCaseName(testing::TestParamInfo<cumSumParams
 
 void CumSumLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShapes;
-    InferenceEngine::Precision inputPrecision;
     bool exclusive, reverse;
     int64_t axis;
     std::tie(inputShapes, inputPrecision, axis, exclusive, reverse, targetDevice) = this->GetParam();

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
@@ -46,7 +46,6 @@ void EltwiseLayerTest::SetUp() {
     ParameterInputIdx primary_input_idx;
     InputLayerType secondary_input_type;
     InferenceEngine::SizeVector inputShape;
-    InferenceEngine::Precision netPrecision;
     ngraph::ParameterVector parameter_inputs;
     std::map<std::string, std::string> additional_config;
     std::tie(op, primary_input_idx, secondary_input_type, netPrecision, inputShape, targetDevice, additional_config) = this->GetParam();

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
@@ -36,8 +36,6 @@ std::string EqualLayerTest::getTestCaseName(const testing::TestParamInfo<EqualTe
 
 void EqualLayerTest::SetUp() {
     std::vector<InferenceEngine::SizeVector> inputShapes;
-    InferenceEngine::Precision inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
-
     std::tie(inputShapes, inputPrecision, outPrc, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
@@ -37,7 +37,6 @@ std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInf
 void ExtractImagePatchesTest::SetUp() {
     std::vector<size_t> inputShape, kernel, strides, rates;
     ngraph::op::PadType pad_type;
-    InferenceEngine::Precision netPrecision;
     std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
@@ -42,7 +42,6 @@ std::string FakeQuantizeLayerTest::getTestCaseName(testing::TestParamInfo<fqLaye
 void FakeQuantizeLayerTest::SetUp() {
     fqSpecificParams fqParams;
     std::vector<size_t> inputShape;
-    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(fqParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     InferenceEngine::SizeVector kernel, stride, dilation;
     size_t levels;

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
@@ -36,8 +36,6 @@ std::string GreaterLayerTest::getTestCaseName(const testing::TestParamInfo<Great
 
 void GreaterLayerTest::SetUp() {
     std::vector<InferenceEngine::SizeVector> inputShapes;
-    InferenceEngine::Precision inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
-
     std::tie(inputShapes, inputPrecision, outPrc, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
@@ -43,7 +43,6 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
 }
 
 void GrnLayerTest::SetUp() {
-    InferenceEngine::Precision netPrecision;
     std::tie(netPrecision, inputShapes, bias, targetDevice) = GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, { inputShapes });

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
@@ -50,7 +50,6 @@ std::string GroupConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<gr
 void GroupConvolutionLayerTest::SetUp() {
     groupConvSpecificParams groupConvParams;
     std::vector<size_t> inputShape;
-    auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(groupConvParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution_backprop_data.cpp
@@ -50,7 +50,6 @@ std::string GroupConvBackpropDataLayerTest::getTestCaseName(testing::TestParamIn
 void GroupConvBackpropDataLayerTest::SetUp() {
     groupConvBackpropDataSpecificParams groupConvBackpropDataParams;
     std::vector<size_t> inputShape;
-    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(groupConvBackpropDataParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::op::PadType padType;
     InferenceEngine::SizeVector kernel, stride, dilation;

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
@@ -35,7 +35,6 @@ std::string LrnLayerTest::getTestCaseName(testing::TestParamInfo<lrnLayerTestPar
 
 void LrnLayerTest::SetUp() {
     std::vector<size_t> inputShapes;
-    auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
     size_t alpha, beta, bias, size;
     std::tie(alpha, beta, bias, size, netPrecision, inputShapes, targetDevice) = GetParam();
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/maximum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/maximum.cpp
@@ -32,7 +32,6 @@ namespace LayerTestsDefinitions {
 
     void MaximumLayerTest::SetUp() {
         std::vector<std::vector<size_t>> inputShapes;
-        InferenceEngine::Precision netPrecision;
         std::tie(inputShapes, netPrecision, targetDevice) = this->GetParam();
         const std::size_t inputDim = InferenceEngine::details::product(inputShapes[0]);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/multiply.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/multiply.cpp
@@ -32,7 +32,6 @@ namespace LayerTestsDefinitions {
 
     void MultiplyLayerTest::SetUp() {
         std::vector<std::vector<size_t>> inputShapes;
-        InferenceEngine::Precision netPrecision;
         std::tie(inputShapes, netPrecision, targetDevice) = this->GetParam();
         const std::size_t input_dim = InferenceEngine::details::product(inputShapes[0]);
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
@@ -40,7 +40,6 @@ std::string MvnLayerTest::getTestCaseName(testing::TestParamInfo<mvnParams> obj)
 
 void MvnLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShapes;
-    InferenceEngine::Precision inputPrecision;
     bool acrossChanels, normalizeVariance;
     double eps;
     std::tie(inputShapes, inputPrecision, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/nonzero.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/nonzero.cpp
@@ -34,7 +34,6 @@ std::string NonZeroLayerTest::getTestCaseName(testing::TestParamInfo<NonZeroLaye
 void NonZeroLayerTest::SetUp() {
     SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
     auto inputShape     = std::vector<std::size_t>{};
-    auto inputPrecision = InferenceEngine::Precision::UNSPECIFIED;
     std::tie(inputShape, inputPrecision, targetDevice) = GetParam();
 
     const auto& precision = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
@@ -63,7 +63,6 @@ std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTe
 void PoolingLayerTest::SetUp() {
     poolSpecificParams poolParams;
     std::vector<size_t> inputShape;
-    InferenceEngine::Precision netPrecision;
     std::tie(poolParams, netPrecision, inputShape, targetDevice) = this->GetParam();
     ngraph::helpers::PoolingTypes poolType;
     std::vector<size_t> kernel, stride;

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
@@ -33,7 +33,6 @@ namespace LayerTestsDefinitions {
 void ReshapeLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShapes, outFormShapes;
     bool specialZero;
-    InferenceEngine::Precision netPrecision;
     std::tie(specialZero, netPrecision, inputShapes, outFormShapes, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
@@ -40,7 +40,6 @@ namespace LayerTestsDefinitions {
         SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
 
         std::vector<std::vector<size_t>> inputShapes(numOfInputs);
-        InferenceEngine::Precision inputPrecision;
         ngraph::op::AutoBroadcastSpec broadcast;
         std::tie(inputShapes, inputPrecision, broadcast, targetDevice) = this->GetParam();
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
@@ -42,7 +42,6 @@ std::string SoftMaxLayerTest::getTestCaseName(testing::TestParamInfo<softMaxLaye
 void SoftMaxLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShape;
     InferenceEngine::Layout inLayout;
-    InferenceEngine::Precision netPrecision;
     size_t axis;
 
     std::tie(netPrecision, inLayout, inputShape, axis, targetDevice) = GetParam();

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_batch.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_batch.cpp
@@ -37,7 +37,6 @@ std::string SpaceToBatchLayerTest::getTestCaseName(const testing::TestParamInfo<
 
 void SpaceToBatchLayerTest::SetUp() {
     std::vector<size_t> inputShape, blockShape, padsBegin, padsEnd;
-    InferenceEngine::Precision inputPrecision, netPrecision;
     std::tie(blockShape, padsBegin, padsEnd, inputShape, netPrecision, targetDevice) = this->GetParam();
 
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
@@ -41,7 +41,6 @@ void SplitLayerTest::SetUp() {
     // SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
     size_t axis, numSplits;
     std::vector<size_t> inputShape;
-    InferenceEngine::Precision netPrecision;
     std::tie(numSplits, axis, netPrecision, inputShape, targetDevice) = this->GetParam();
     auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {inputShape});

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
@@ -47,7 +47,6 @@ void StridedSliceLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShape;
     std::vector<int64_t> begin, end, stride;
     std::vector<int64_t> begin_mask, end_mask, new_axis_mask, shrink_mask, ellipsis_mask;
-    InferenceEngine::Precision netPrecision;
     std::tie(inputShape, begin, end, stride, begin_mask, end_mask, new_axis_mask, shrink_mask, ellipsis_mask,
              netPrecision, targetDevice) = this->GetParam();
 

--- a/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
+++ b/inference-engine/tests/ie_test_utils/functional_test_utils/layer_test_utils.hpp
@@ -46,6 +46,10 @@ public:
         // Create CNNNetwork from ngrpah::Function
         InferenceEngine::CNNNetwork cnnNet(fnPtr);
         // Set target input Precisions for the network
+        IE_ASSERT(netPrecision != InferenceEngine::Precision::UNSPECIFIED);
+        if (inputPrecision == InferenceEngine::Precision::UNSPECIFIED) {
+            inputPrecision = netPrecision;
+        }
         setNetInOutPrecision(cnnNet, inputPrecision);
 
         // Get Core from cache


### PR DESCRIPTION
Fixes supplying precision information in test cases in two key ways:
1. When only network precision is supplied, use that precision as the input precision as well
2. For precision member variables of test classes, do not declare local variables with the same name during `SetUp`. The member variables need to be updated by `SetUp`.

Note that these 2 pieces of the change are provided in separate commits in this PR.