### PR TITLE
Add unsqueeze test

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/unsqueeze.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/unsqueeze.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    std::vector<int64_t>,               // Axes
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> unsqueezeParams;
+
+class UnsqueezeLayerTest : public LayerTestsUtils::LayerTestsCommonClass<unsqueezeParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<unsqueezeParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/unsqueeze.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/unsqueeze.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/unsqueeze.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string UnsqueezeLayerTest::getTestCaseName(testing::TestParamInfo<unsqueezeParams> obj) {
+    std::vector<int64_t> axes;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(axes, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "axes_" << CommonTestUtils::vec2str(axes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void UnsqueezeLayerTest::SetUp() {
+    std::vector<int64_t> axes;
+    std::vector<size_t> inputShape;
+    std::tie(axes, netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto AxesOp = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{axes.size()},
+                                                                  axes);
+    const auto unsqueeze = std::make_shared<ngraph::opset1::Unsqueeze>(paramOuts.at(0), AxesOp);
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(unsqueeze));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "unsqueeze");
+}
+
+TEST_P(UnsqueezeLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions


### PR DESCRIPTION
This was partially an exercise in determining the difficulty of adding basic single layer tests for relatively simple ops. It does also add a test for unsqueeze.