### PR TITLE
Backport makeMVN from upstream

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mvn.hpp
@@ -14,7 +14,7 @@ namespace LayerTestsDefinitions {
 
 typedef std::tuple<
         InferenceEngine::SizeVector, // Input shapes
-        InferenceEngine::Precision,  // Input precision
+        InferenceEngine::Precision,  // Net precision
         bool,                        // Across channels
         bool,                        // Normalize variance
         double,                      // Epsilon

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
@@ -23,17 +23,17 @@ namespace LayerTestsDefinitions {
 
 std::string MvnLayerTest::getTestCaseName(testing::TestParamInfo<mvnParams> obj) {
     InferenceEngine::SizeVector inputShapes;
-    InferenceEngine::Precision inputPrecision;
+    InferenceEngine::Precision netPrecision;
     bool acrossChannels, normalizeVariance;
     double eps;
     std::string targetDevice;
-    std::tie(inputShapes, inputPrecision, acrossChannels, normalizeVariance, eps, targetDevice) = obj.param;
+    std::tie(inputShapes, netPrecision, acrossChannels, normalizeVariance, eps, targetDevice) = obj.param;
     std::ostringstream result;
     result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "Precision_" << inputPrecision.name() << "_";
+    result << "Precision_" << netPrecision.name() << "_";
     result << "AcrossChannels_" << (acrossChannels ? "TRUE" : "FALSE") << "_";
     result << "NormalizeVariance_" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
-    result << "Epsilon_" << eps << "_";
+    result << "EpsilonTimes1000000000_" << eps * 1000000000 << "_";
     result << "TargetDevice_" << targetDevice;
     return result.str();
 }
@@ -42,8 +42,8 @@ void MvnLayerTest::SetUp() {
     InferenceEngine::SizeVector inputShapes;
     bool acrossChanels, normalizeVariance;
     double eps;
-    std::tie(inputShapes, inputPrecision, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();
-    auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    std::tie(inputShapes, netPrecision, acrossChanels, normalizeVariance, eps, targetDevice) = this->GetParam();
+    auto inType = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
     auto param = ngraph::builder::makeParams(inType, {inputShapes});
     auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(param));
     auto mvn = std::dynamic_pointer_cast<ngraph::op::MVN>(ngraph::builder::makeMVN(paramOuts[0], acrossChanels, normalizeVariance, eps));

--- a/inference-engine/tests/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -33,6 +33,11 @@ std::shared_ptr<ngraph::Node> makeConvolution(const ngraph::Output<Node> &in,
                                               const std::vector<float> &filterWeights = {},
                                               const std::vector<float> &biasesWeights = {});
 
+std::shared_ptr<ngraph::Node> makeMVN(const ngraph::Output<Node> &in,
+                                      bool acrossChannels,
+                                      bool normalizeVariance,
+                                      double eps);
+
 std::shared_ptr<ngraph::Node> makeSplit(const ngraph::Output<Node> &in,
                                         const element::Type &type,
                                         size_t numSplits,

--- a/inference-engine/tests/ngraph_functions/src/mvn.cpp
+++ b/inference-engine/tests/ngraph_functions/src/mvn.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/builders.hpp"
+
+namespace ngraph {
+namespace builder {
+
+std::shared_ptr<ngraph::Node> makeMVN(const ngraph::Output<Node> &in,
+                                      bool acrossChannels,
+                                      bool normalizeVariance,
+                                      double eps) {
+    auto mvnNode = std::make_shared<ngraph::op::MVN>(in, acrossChannels, normalizeVariance, eps);
+
+    // Ngraph MVN implementation implicitly adds 0th dimension to reduction axes set which is not valid behavior
+    ngraph::AxisSet axes;
+    const size_t startAxis = acrossChannels ? 1 : 2;
+    const size_t numOfDims = in.get_shape().size();
+    for (size_t i = startAxis; i < numOfDims; i++)
+        axes.insert(i);
+    mvnNode->set_reduction_axes(axes);
+
+    return mvnNode;
+}
+
+}  // namespace builder
+}  // namespace ngraph


### PR DESCRIPTION
(also backport MVN testing to match 2020.2 test structure)