### PR TITLE
Add & backport tests for several ops

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/mat_mul.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+typedef std::tuple<
+        InferenceEngine::Precision,
+        InferenceEngine::SizeVector,
+        InferenceEngine::SizeVector,
+        std::string
+> MatMulLayerTestParamsSet;
+
+namespace LayerTestsDefinitions {
+
+class MatMulTest : public LayerTestsUtils::LayerTestsCommonClass<MatMulLayerTestParamsSet>  {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<MatMulLayerTestParamsSet> &obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reverse_sequence.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/reverse_sequence.hpp
@@ -1,0 +1,34 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    int64_t,                        // batch_axis
+    int64_t,                        // seq_axis
+    std::vector<size_t>,            // lengths
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> reverseSequenceParams;
+
+class ReverseSequenceLayerTest : public LayerTestsUtils::LayerTestsCommonClass<reverseSequenceParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<reverseSequenceParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/shape_of.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/shape_of.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> shapeOfParams;
+
+class ShapeOfLayerTest : public LayerTestsUtils::LayerTestsCommonClass<shapeOfParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<shapeOfParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/sin.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/sin.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> sinParams;
+
+class SinLayerTest : public LayerTestsUtils::LayerTestsCommonClass<sinParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<sinParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/sinh.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/sinh.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> sinhParams;
+
+class SinhLayerTest : public LayerTestsUtils::LayerTestsCommonClass<sinhParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<sinhParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_depth.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/space_to_depth.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+
+namespace LayerTestsDefinitions {
+
+using spaceToDepthParamsTuple = typename std::tuple<
+        std::vector<size_t>,                            // Input shape
+        InferenceEngine::Precision,                     // Input precision
+        ngraph::opset1::SpaceToDepth::SpaceToDepthMode, // Mode
+        std::size_t,                                    // Block size
+        std::string>;                                   // Device name>
+
+class SpaceToDepthLayerTest : public LayerTestsUtils::LayerTestsCommonClass<spaceToDepthParamsTuple> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<spaceToDepthParamsTuple> &obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/sqrt.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/sqrt.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> sqrtParams;
+
+class SqrtLayerTest : public LayerTestsUtils::LayerTestsCommonClass<sqrtParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<sqrtParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/squared_difference.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/squared_difference.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<std::vector<size_t>>,   // Input shapes
+    std::string                     // Target device name
+> squaredDifferenceParams;
+
+class SquaredDifferenceLayerTest : public LayerTestsUtils::LayerTestsCommonClass<squaredDifferenceParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<squaredDifferenceParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/squeeze.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/squeeze.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    std::vector<int64_t>,               // indexes_to_squeeze
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> squeezeParams;
+
+class SqueezeLayerTest : public LayerTestsUtils::LayerTestsCommonClass<squeezeParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<squeezeParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/subtract.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/subtract.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<std::vector<size_t>>,   // Input shapes
+    std::string                     // Target device name
+> subtractParams;
+
+class SubtractLayerTest : public LayerTestsUtils::LayerTestsCommonClass<subtractParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<subtractParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/tan.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/tan.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> tanParams;
+
+class TanLayerTest : public LayerTestsUtils::LayerTestsCommonClass<tanParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<tanParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/tile.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/tile.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+typedef std::tuple<
+    std::vector<int64_t>,           // repeats
+    InferenceEngine::Precision,     // Net precision
+    std::vector<size_t>,            // Input shapes
+    std::string                     // Target device name
+> tileParams;
+
+class TileLayerTest : public LayerTestsUtils::LayerTestsCommonClass<tileParams> {
+public:
+    static std::string getTestCaseName(testing::TestParamInfo<tileParams> obj);
+
+protected:
+    void SetUp() override;
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mat_mul.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "single_layer_tests/mat_mul.hpp"
+#include "ngraph_functions/builders.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string MatMulTest::getTestCaseName(const testing::TestParamInfo<MatMulLayerTestParamsSet> &obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShape0;
+    InferenceEngine::SizeVector inputShape1;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShape0, inputShape1, targetDevice) = obj.param;
+
+    std::ostringstream result;
+    result << "IS0=" << CommonTestUtils::vec2str(inputShape0) << "_";
+    result << "IS1=" << CommonTestUtils::vec2str(inputShape1) << "_";
+    result << "netPRC=" << netPrecision.name() << "_";
+    result << "targetDevice=" << targetDevice;
+    return result.str();
+}
+
+void MatMulTest::SetUp() {
+    InferenceEngine::SizeVector inputShape0;
+    InferenceEngine::SizeVector inputShape1;
+    auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
+    std::tie(netPrecision, inputShape0, inputShape1, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape0, inputShape1});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+    auto MatMul = std::dynamic_pointer_cast<ngraph::opset1::MatMul>(
+            ngraph::builder::makeMatMul(paramOuts[0], paramOuts[1]));
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(MatMul)};
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "MatMul");
+}
+
+TEST_P(MatMulTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reverse_sequence.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reverse_sequence.cpp
@@ -1,0 +1,67 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/reverse_sequence.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string ReverseSequenceLayerTest::getTestCaseName(testing::TestParamInfo<reverseSequenceParams> obj) {
+    int64_t batch_axis;
+    int64_t seq_axis;
+    std::vector<size_t> lengths;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(batch_axis, seq_axis, lengths, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "BA_" << batch_axis << "_";
+    result << "SA_" << seq_axis << "_";
+    result << "L_" << CommonTestUtils::vec2str(lengths) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void ReverseSequenceLayerTest::SetUp() {
+    int64_t batch_axis;
+    int64_t seq_axis;
+    std::vector<size_t> lengths;
+    std::vector<size_t> inputShape;
+    std::tie(batch_axis, seq_axis, lengths, netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    // TODO
+    const auto LengthsOp = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{lengths.size()},
+                                                                  lengths);
+    const auto reverse_sequence = std::make_shared<ngraph::opset1::ReverseSequence>(paramOuts.at(0), LengthsOp, batch_axis, seq_axis);
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(reverse_sequence));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "reverse_sequence");
+}
+
+TEST_P(ReverseSequenceLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
@@ -37,8 +37,6 @@ namespace LayerTestsDefinitions {
     }
 
     void SelectLayerTest::SetUp() {
-        SetRefMode(LayerTestsUtils::RefMode::CONSTANT_FOLDING);
-
         std::vector<std::vector<size_t>> inputShapes(numOfInputs);
         ngraph::op::AutoBroadcastSpec broadcast;
         std::tie(inputShapes, inputPrecision, broadcast, targetDevice) = this->GetParam();

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/shape_of.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/shape_of.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/shape_of.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string ShapeOfLayerTest::getTestCaseName(testing::TestParamInfo<shapeOfParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void ShapeOfLayerTest::SetUp() {
+    std::vector<size_t> inputShape;
+    std::tie(netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto shape_of = std::make_shared<ngraph::opset1::ShapeOf>(paramOuts.at(0));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(shape_of));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "shape_of");
+}
+
+TEST_P(ShapeOfLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/sin.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/sin.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/sin.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string SinLayerTest::getTestCaseName(testing::TestParamInfo<sinParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void SinLayerTest::SetUp() {
+    std::vector<size_t> inputShape;
+    std::tie(netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto sin = std::make_shared<ngraph::opset1::Sin>(paramOuts.at(0));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(sin));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "sin");
+}
+
+TEST_P(SinLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/sinh.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/sinh.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/sinh.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string SinhLayerTest::getTestCaseName(testing::TestParamInfo<sinhParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void SinhLayerTest::SetUp() {
+    std::vector<size_t> inputShape;
+    std::tie(netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto sinh = std::make_shared<ngraph::opset1::Sinh>(paramOuts.at(0));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(sinh));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "sinh");
+}
+
+TEST_P(SinhLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_depth.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_depth.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include <ie_core.hpp>
+#include <ngraph_functions/builders.hpp>
+
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/precision_utils.hpp"
+#include "common_test_utils/common_utils.hpp"
+
+#include "single_layer_tests/space_to_depth.hpp"
+
+// using namespace ngraph::opset1;
+using ngraph::opset1::SpaceToDepth;
+
+namespace LayerTestsDefinitions {
+
+static inline std::string SpaceToDepthModeToString(const SpaceToDepth::SpaceToDepthMode& mode) {
+    static std::map<SpaceToDepth::SpaceToDepthMode, std::string> names = {
+        {SpaceToDepth::SpaceToDepthMode::BLOCKS_FIRST, "BLOCKS_FIRST"},
+        {SpaceToDepth::SpaceToDepthMode::DEPTH_FIRST, "DEPTH_FIRST"},
+    };
+
+    auto i = names.find(mode);
+    if (i != names.end())
+        return i->second;
+    else
+        throw std::runtime_error("Unsupported SpaceToDepthMode");
+}
+
+std::string SpaceToDepthLayerTest::getTestCaseName(const testing::TestParamInfo<spaceToDepthParamsTuple> &obj) {
+    std::vector<size_t> inShape;
+    SpaceToDepth::SpaceToDepthMode mode;
+    std::size_t blockSize;
+    InferenceEngine::Precision inputPrecision;
+    std::string targetName;
+    std::tie(inShape, inputPrecision, mode, blockSize, targetName) = obj.param;
+    std::ostringstream result;
+    result << "IS=" << CommonTestUtils::vec2str(inShape) << "_";
+    result << "inPrc=" << inputPrecision.name() << "_";
+    result << "M=" << SpaceToDepthModeToString(mode) << "_";
+    result << "BS=" << blockSize << "_";
+    result << "targetDevice=" << targetName << "_";
+    return result.str();
+}
+
+void SpaceToDepthLayerTest::SetUp() {
+    std::vector<size_t> inShape;
+    SpaceToDepth::SpaceToDepthMode mode;
+    std::size_t blockSize;
+    InferenceEngine::Precision inputPrecision;
+    std::tie(inShape, inputPrecision, mode, blockSize, targetDevice) = this->GetParam();
+    auto inPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inputPrecision);
+    auto params = ngraph::builder::makeParams(inPrc, {inShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+    auto s2d = ngraph::builder::makeSpaceToDepth(paramOuts[0], mode, blockSize);
+    ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(s2d)};
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "SpaceToDepth");
+}
+
+TEST_P(SpaceToDepthLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/sqrt.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/sqrt.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/sqrt.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string SqrtLayerTest::getTestCaseName(testing::TestParamInfo<sqrtParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void SqrtLayerTest::SetUp() {
+    std::vector<size_t> inputShape;
+    std::tie(netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto sqrt = std::make_shared<ngraph::opset1::Sqrt>(paramOuts.at(0));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(sqrt));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "sqrt");
+}
+
+TEST_P(SqrtLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/squared_difference.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/squared_difference.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/squared_difference.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string SquaredDifferenceLayerTest::getTestCaseName(testing::TestParamInfo<squaredDifferenceParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    std::vector<std::vector<size_t>> inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void SquaredDifferenceLayerTest::SetUp() {
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    std::tie(netPrecision, inputShapes, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});
+
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    IE_ASSERT(paramOuts.size() == 2);
+    const auto squared_difference = std::make_shared<ngraph::opset1::SquaredDifference>(paramOuts.at(0), paramOuts.at(1));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(squared_difference));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "squared_difference");
+}
+
+TEST_P(SquaredDifferenceLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/squeeze.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/squeeze.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/squeeze.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string SqueezeLayerTest::getTestCaseName(testing::TestParamInfo<squeezeParams> obj) {
+    std::vector<int64_t> indexes_to_squeeze;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(indexes_to_squeeze, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "ItS_" << CommonTestUtils::vec2str(indexes_to_squeeze) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void SqueezeLayerTest::SetUp() {
+    std::vector<int64_t> indexes_to_squeeze;
+    std::vector<size_t> inputShape;
+    std::tie(indexes_to_squeeze, netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto IdxsToSqueezeOp = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{indexes_to_squeeze.size()},
+                                                                  indexes_to_squeeze);
+    const auto squeeze = std::make_shared<ngraph::opset1::Squeeze>(paramOuts.at(0), IdxsToSqueezeOp);
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(squeeze));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "squeeze");
+}
+
+TEST_P(SqueezeLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/subtract.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/subtract.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/subtract.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string SubtractLayerTest::getTestCaseName(testing::TestParamInfo<subtractParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    std::vector<std::vector<size_t>> inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void SubtractLayerTest::SetUp() {
+    std::vector<InferenceEngine::SizeVector> inputShapes;
+    std::tie(netPrecision, inputShapes, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShapes});
+
+    auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShapes});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+    IE_ASSERT(paramOuts.size() == 2);
+    const auto subtract = std::make_shared<ngraph::opset1::Subtract>(paramOuts.at(0), paramOuts.at(1));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(subtract));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "subtract");
+}
+
+TEST_P(SubtractLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/tan.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/tan.cpp
@@ -1,0 +1,55 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/tan.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string TanLayerTest::getTestCaseName(testing::TestParamInfo<tanParams> obj) {
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void TanLayerTest::SetUp() {
+    std::vector<size_t> inputShape;
+    std::tie(netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto tan = std::make_shared<ngraph::opset1::Tan>(paramOuts.at(0));
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(tan));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "tan");
+}
+
+TEST_P(TanLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/tile.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/tile.cpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/tile.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string TileLayerTest::getTestCaseName(testing::TestParamInfo<tileParams> obj) {
+    std::vector<int64_t> repeats;
+    InferenceEngine::Precision netPrecision;
+    InferenceEngine::SizeVector inputShapes;
+    std::string targetDevice;
+    std::tie(repeats, netPrecision, inputShapes, targetDevice) = obj.param;
+    std::ostringstream result;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "R_" << CommonTestUtils::vec2str(repeats) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
+    return result.str();
+}
+
+void TileLayerTest::SetUp() {
+    // TODO
+    std::vector<int64_t> repeats;
+    std::vector<size_t> inputShape;
+    std::tie(repeats, netPrecision, inputShape, targetDevice) = this->GetParam();
+    auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
+    auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+    auto paramOuts = ngraph::helpers::convert2OutputVector(
+            ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+
+    const auto RepeatsOp = std::make_shared<ngraph::opset1::Constant>(ngraph::element::Type_t::i64, ngraph::Shape{repeats.size()},
+                                                                  repeats);
+    const auto tile = std::make_shared<ngraph::opset1::Tile>(paramOuts.at(0), RepeatsOp);
+
+    ngraph::ResultVector results;
+    results.push_back(std::make_shared<ngraph::opset1::Result>(tile));
+    fnPtr = std::make_shared<ngraph::Function>(results, params, "tile");
+}
+
+TEST_P(TileLayerTest, CompareWithRefs) {
+    inferAndValidate();
+};
+
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -42,6 +42,12 @@ std::shared_ptr<ngraph::Node> makeActivation(const ngraph::Output<Node> &in,
                                              const element::Type &type,
                                              ngraph::helpers::ActivationTypes activationType);
 
+std::shared_ptr<ngraph::Node> makeMatMul(const ngraph::Output<Node>& A,
+                                         const ngraph::Output<Node>& B);
+
+std::shared_ptr<ngraph::Node> makeSelect(std::vector<ngraph::Output<Node>> &in,
+                                         const ngraph::op::AutoBroadcastSpec& auto_broadcast);
+
 std::shared_ptr<ngraph::Node> makeBatchToSpace(const ngraph::Output<Node> &in,
                                                const element::Type &type,
                                                const std::vector<size_t> &blockShape,
@@ -53,5 +59,9 @@ std::shared_ptr<ngraph::Node> makeSpaceToBatch(const ngraph::Output<Node> &in,
                                                const std::vector<size_t> &blockShape,
                                                const std::vector<size_t> &padsBegin,
                                                const std::vector<size_t> &padsEnd);
+
+std::shared_ptr<ngraph::Node> makeSpaceToDepth(const ngraph::Output<Node> &in,
+                                               ngraph::opset1::SpaceToDepth::SpaceToDepthMode mode,
+                                               size_t blockSize);
 }  // namespace builder
 }  // namespace ngraph

--- a/inference-engine/tests/ngraph_functions/src/mat_mul.cpp
+++ b/inference-engine/tests/ngraph_functions/src/mat_mul.cpp
@@ -1,0 +1,16 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/builders.hpp"
+
+namespace ngraph {
+namespace builder {
+
+std::shared_ptr<Node> makeMatMul(const Output<Node>& A,
+                                 const Output<Node>& B) {
+    return std::make_shared<ngraph::opset1::MatMul>(A, B);
+}
+
+}  // namespace builder
+}  // namespace ngraph

--- a/inference-engine/tests/ngraph_functions/src/select.cpp
+++ b/inference-engine/tests/ngraph_functions/src/select.cpp
@@ -1,0 +1,18 @@
+  
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/builders.hpp"
+
+namespace ngraph {
+namespace builder {
+
+std::shared_ptr<ngraph::Node> makeSelect(std::vector<ngraph::Output<Node>> &in,
+                                         const ngraph::op::AutoBroadcastSpec& auto_broadcast) {
+    auto selectNode = std::make_shared<ngraph::opset1::Select>(in[0], in[1], in[2], auto_broadcast);
+    return selectNode;
+}
+
+}  // namespace builder
+}  // namespace ngraph

--- a/inference-engine/tests/ngraph_functions/src/space_to_depth.cpp
+++ b/inference-engine/tests/ngraph_functions/src/space_to_depth.cpp
@@ -1,0 +1,18 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "ngraph_functions/builders.hpp"
+
+namespace ngraph {
+namespace builder {
+
+std::shared_ptr<ngraph::Node> makeSpaceToDepth(const ngraph::Output<Node> &in,
+                                               ngraph::opset1::SpaceToDepth::SpaceToDepthMode mode,
+                                               size_t blockSize) {
+    auto dtsNode = std::make_shared<ngraph::opset1::SpaceToDepth>(in, mode, blockSize);
+    return dtsNode;
+}
+
+}  // namespace builder
+}  // namespace ngraph


### PR DESCRIPTION
Add tests for Tile, Tan, Subtract, Squeeze, SquaredDifference, Sqrt, Sinh, Sin, ShapeOf, & ReverseSequence.

Backport tests for SpaceToDepth & MatMul.

Fix tests for Select.