### PR TITLE
Fixed test names

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/unique_node_names.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/execution_graph_tests/unique_node_names.cpp
@@ -29,10 +29,10 @@ std::string ExecGraphUniqueNodeNames::getTestCaseName(testing::TestParamInfo<Lay
     std::tie(inputPrecision, netPrecision, inputShapes, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "inPRC=" << inputPrecision.name() << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "inPRC_" << inputPrecision.name() << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/ctc_greedy_decoder.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/ctc_greedy_decoder.cpp
@@ -36,10 +36,10 @@ std::string CTCGreedyDecoderLayerTest::getTestCaseName(
     std::ostringstream result;
     const char separator = '_';
 
-    result << "IS="     << CommonTestUtils::vec2str(inputShapes) << separator;
-    result << "netPRC=" << netPrecision.name() << separator;
-    result << "merge_repeated=" << std::boolalpha << mergeRepeated << separator;
-    result << "targetDevice=" << targetDevice;
+    result << "IS_"     << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "netPRC_" << netPrecision.name() << separator;
+    result << "merge_repeated_" << std::boolalpha << mergeRepeated << separator;
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
@@ -25,9 +25,9 @@ std::string EqualLayerTest::getTestCaseName(const testing::TestParamInfo<EqualTe
     std::tie(inputShapes, netPrecision, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "netPrc=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPrc_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
@@ -25,9 +25,9 @@ std::string GreaterLayerTest::getTestCaseName(const testing::TestParamInfo<Great
     std::tie(inputShapes, netPrecision, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "netPrc=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPrc_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater_equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater_equal.cpp
@@ -25,9 +25,9 @@ std::string GreaterEqualLayerTest::getTestCaseName(const testing::TestParamInfo<
     std::tie(inputShapes, netPrecision, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "netPrc=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPrc_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
@@ -35,10 +35,10 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
     std::ostringstream result;
     const char separator = '_';
 
-    result << "IS="     << CommonTestUtils::vec2str(inputShapes) << separator;
-    result << "netPRC=" << netPrecision.name() << separator;
-    result << "bias="   << bias << separator;
-    result << "targetDevice=" << targetDevice;
+    result << "IS_"     << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "netPRC_" << netPrecision.name() << separator;
+    result << "bias_"   << bias << separator;
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mat_mul.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mat_mul.cpp
@@ -21,10 +21,10 @@ std::string MatMulTest::getTestCaseName(const testing::TestParamInfo<MatMulLayer
     std::tie(netPrecision, inputShape0, inputShape1, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS0=" << CommonTestUtils::vec2str(inputShape0) << "_";
-    result << "IS1=" << CommonTestUtils::vec2str(inputShape1) << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS0_" << CommonTestUtils::vec2str(inputShape0) << "_";
+    result << "IS1_" << CommonTestUtils::vec2str(inputShape1) << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/maximum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/maximum.cpp
@@ -24,9 +24,9 @@ namespace LayerTestsDefinitions {
         std::tie(inputShapes, netPrecision, targetName) = obj.param;
         std::ostringstream results;
 
-        results << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-        results << "netPRC=" << netPrecision.name() << "_";
-        results << "targetDevice=" << targetName << "_";
+        results << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+        results << "netPRC_" << netPrecision.name() << "_";
+        results << "targetDevice_" << targetName << "_";
         return results.str();
     }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/minimum.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/minimum.cpp
@@ -24,9 +24,9 @@ namespace LayerTestsDefinitions {
         std::tie(inputShapes, netPrecision, targetName) = obj.param;
         std::ostringstream results;
 
-        results << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-        results << "netPRC=" << netPrecision.name() << "_";
-        results << "targetDevice=" << targetName << "_";
+        results << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+        results << "netPRC_" << netPrecision.name() << "_";
+        results << "targetDevice_" << targetName << "_";
         return results.str();
     }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/not_equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/not_equal.cpp
@@ -25,9 +25,9 @@ std::string NotEqualLayerTest::getTestCaseName(const testing::TestParamInfo<NotE
     std::tie(inputShapes, netPrecision, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "netPrc=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "netPrc_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
 
     return result.str();
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/prior_box_clustered.cpp
@@ -48,21 +48,21 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
     std::ostringstream result;
     const char separator = '_';
 
-    result << "IS="      << CommonTestUtils::vec2str(inputShapes) << separator;
-    result << "imageS="  << CommonTestUtils::vec2str(imageShapes) << separator;
-    result << "netPRC="  << netPrecision.name()   << separator;
-    result << "widths="  << CommonTestUtils::vec2str(widths)  << separator;
-    result << "heights=" << CommonTestUtils::vec2str(heights) << separator;
-    result << "variances=";
+    result << "IS_"      << CommonTestUtils::vec2str(inputShapes) << separator;
+    result << "imageS_"  << CommonTestUtils::vec2str(imageShapes) << separator;
+    result << "netPRC_"  << netPrecision.name()   << separator;
+    result << "widths_"  << CommonTestUtils::vec2str(widths)  << separator;
+    result << "heights_" << CommonTestUtils::vec2str(heights) << separator;
+    result << "variances_";
     if (variances.empty())
         result << "()" << separator;
     else
         result << CommonTestUtils::vec2str(variances) << separator;
-    result << "stepWidth="  << step_width  << separator;
-    result << "stepHeight=" << step_height << separator;
-    result << "offset="     << offset      << separator;
-    result << "clip=" << std::boolalpha << clip << separator;
-    result << "targetDevice=" << targetDevice;
+    result << "stepWidth_"  << step_width  << separator;
+    result << "stepHeight_" << step_height << separator;
+    result << "offset_"     << offset      << separator;
+    result << "clip_" << std::boolalpha << clip << separator;
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
@@ -29,17 +29,17 @@ std::string StridedSliceLayerTest::getTestCaseName(const testing::TestParamInfo<
     std::tie(inputShape, begin, end, stride, begin_mask, end_mask, new_axis_mask, shrink_mask, ellipsis_mask, netPrc,
              targetName) = obj.param;
     std::ostringstream result;
-    result << "inShape=" << CommonTestUtils::vec2str(inputShape) << "_";
-    result << "netPRC=" << netPrc.name() << "_";
-    result << "begin=" << CommonTestUtils::vec2str(begin) << "_";
-    result << "end=" << CommonTestUtils::vec2str(end) << "_";
-    result << "stride=" << CommonTestUtils::vec2str(stride) << "_";
-    result << "begin_m=" << CommonTestUtils::vec2str(begin_mask) << "_";
-    result << "end_m=" << CommonTestUtils::vec2str(end_mask) << "_";
-    result << "new_axis_m=" << CommonTestUtils::vec2str(new_axis_mask) << "_";
-    result << "shrink_m=" << CommonTestUtils::vec2str(shrink_mask) << "_";
-    result << "ellipsis_m=" << CommonTestUtils::vec2str(ellipsis_mask) << "_";
-    result << "targetDevice=" << targetName << "_";
+    result << "inShape_" << CommonTestUtils::vec2str(inputShape) << "_";
+    result << "netPRC_" << netPrc.name() << "_";
+    result << "begin_" << CommonTestUtils::vec2str(begin) << "_";
+    result << "end_" << CommonTestUtils::vec2str(end) << "_";
+    result << "stride_" << CommonTestUtils::vec2str(stride) << "_";
+    result << "begin_m_" << CommonTestUtils::vec2str(begin_mask) << "_";
+    result << "end_m_" << CommonTestUtils::vec2str(end_mask) << "_";
+    result << "new_axis_m_" << CommonTestUtils::vec2str(new_axis_mask) << "_";
+    result << "shrink_m_" << CommonTestUtils::vec2str(shrink_mask) << "_";
+    result << "ellipsis_m_" << CommonTestUtils::vec2str(ellipsis_mask) << "_";
+    result << "targetDevice_" << targetName << "_";
     return result.str();
 }
 

--- a/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/split_conv_concat.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/subgraph_tests/split_conv_concat.cpp
@@ -28,10 +28,10 @@ std::string SplitConvConcat::getTestCaseName(testing::TestParamInfo<LayerTestsUt
     std::tie(inputPrecision, netPrecision, inputShapes, targetDevice) = obj.param;
 
     std::ostringstream result;
-    result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
-    result << "inPRC=" << inputPrecision.name() << "_";
-    result << "netPRC=" << netPrecision.name() << "_";
-    result << "targetDevice=" << targetDevice;
+    result << "IS_" << CommonTestUtils::vec2str(inputShapes) << "_";
+    result << "inPRC_" << inputPrecision.name() << "_";
+    result << "netPRC_" << netPrecision.name() << "_";
+    result << "targetDevice_" << targetDevice;
     return result.str();
 }
 


### PR DESCRIPTION
The equal sign instead of underscore that some of the test names had seems to cause the test name to be invalid