### PR TITLE
Fixed test naming scheme where necessary

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_norm_inference.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_norm_inference.cpp
@@ -32,7 +32,10 @@ std::string BatchNormInferenceLayerTest::getTestCaseName(testing::TestParamInfo<
     result << "Eps_" << epsilon << "_";
     result << "netPRC_" << netPrecision.name() << "_";
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void BatchNormInferenceLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/clamp.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/clamp.cpp
@@ -34,7 +34,10 @@ std::string ClampLayerTest::getTestCaseName(testing::TestParamInfo<clampParams> 
     result << "MAX_" << max << "_";
     result << "netPRC_" << netPrecision.name() << "_";
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void ClampLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/elu.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/elu.cpp
@@ -32,7 +32,10 @@ std::string EluLayerTest::getTestCaseName(testing::TestParamInfo<eluParams> obj)
     result << "A_" << alpha << "_";
     result << "netPRC_" << netPrecision.name() << "_";
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void EluLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
@@ -39,7 +39,10 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
     result << "netPRC_" << netPrecision.name() << separator;
     result << "bias_"   << bias << separator;
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void GrnLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/hard_sigmoid.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/hard_sigmoid.cpp
@@ -34,7 +34,10 @@ std::string HardSigmoidLayerTest::getTestCaseName(testing::TestParamInfo<hardSig
     result << "B_" << beta << "_";
     result << "netPRC_" << netPrecision.name() << "_";
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void HardSigmoidLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
@@ -29,8 +29,10 @@ std::string LrnLayerTest::getTestCaseName(testing::TestParamInfo<lrnLayerTestPar
     result << "Size_" << size << separator;
     result << "netPRC_" << netPrecision.name() << separator;
     result << "targetDevice_" << targetDevice;
-
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void LrnLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
@@ -35,7 +35,10 @@ std::string MvnLayerTest::getTestCaseName(testing::TestParamInfo<mvnParams> obj)
     result << "NormalizeVariance_" << (normalizeVariance ? "TRUE" : "FALSE") << "_";
     result << "EpsilonTimes1000000000_" << eps * 1000000000 << "_";
     result << "TargetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void MvnLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/normalize_l2.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/normalize_l2.cpp
@@ -36,7 +36,10 @@ std::string NormalizeL2LayerTest::getTestCaseName(testing::TestParamInfo<normali
     result << "EM_" << eps_mode << "_";
     result << "netPRC_" << netPrecision.name() << "_";
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void NormalizeL2LayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/one_hot.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/one_hot.cpp
@@ -37,7 +37,10 @@ std::string OneHotLayerTest::getTestCaseName(testing::TestParamInfo<oneHotParams
     result << "OFF_" << off_value << "_";
     result << "netPRC_" << netPrecision.name() << "_";
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void OneHotLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/prior_box_clustered.cpp
@@ -63,7 +63,10 @@ std::string PriorBoxClusteredLayerTest::getTestCaseName(const testing::TestParam
     result << "offset_"     << offset      << separator;
     result << "clip_" << std::boolalpha << clip << separator;
     result << "targetDevice_" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 std::vector<std::vector<std::uint8_t>> PriorBoxClusteredLayerTest::CalculateRefs() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/proposal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/proposal.cpp
@@ -67,8 +67,10 @@ std::string ProposalLayerTest::getTestCaseName(testing::TestParamInfo<proposalLa
     result << "box_coordinate_scale=" << box_coordinate_scale << "_";
     result << "framework=" << framework << "_";
     result << "targetDevice=" << targetDevice;
-
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    return string;
 }
 
 void ProposalLayerTest::SetUp() {


### PR DESCRIPTION
Replaces periods with dashes for ops that have float/double arguments