### PR TITLE
Move PlaidML changes forward to OV `master` branch

### DIFF
--- a/inference-engine/src/inference_engine/ie_blob_stream.cpp
+++ b/inference-engine/src/inference_engine/ie_blob_stream.cpp
@@ -22,15 +22,15 @@ InferenceEngine::details::BlobStream::BlobBuffer::~BlobBuffer() {}
 
 std::streampos InferenceEngine::details::BlobStream::BlobBuffer::seekpos(std::streampos sp, std::ios_base::openmode which) {
     if (!(which & ios_base::in))
-        return streampos(-1);
+        return std::streampos(-1);
     if (sp < 0 || sp > egptr() - eback())
-        return streampos(-1);
+        return std::streampos(-1);
     setg(eback(), eback() + sp, egptr());
     return sp;
 }
 std::streampos InferenceEngine::details::BlobStream::BlobBuffer::seekoff(std::streamoff off, std::ios_base::seekdir way, std::ios_base::openmode which) {
     if (!(which & std::ios_base::in))
-        return streampos(-1);
+        return std::streampos(-1);
     switch (way) {
     default:
     case std::ios_base::beg:

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/activation.cpp
@@ -33,7 +33,13 @@ std::string ActivationLayerTest::getTestCaseName(const testing::TestParamInfo<ac
     result << "AS=" << CommonTestUtils::vec2str(shapes.second) << separator;;
     result << "netPRC=" << netPrecision.name() << separator;
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ActivationLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/batch_to_space.cpp
@@ -32,7 +32,13 @@ std::string BatchToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
     result << "CB=" << CommonTestUtils::vec2str(cropsBegin) << "_";
     result << "CE=" << CommonTestUtils::vec2str(cropsEnd) << "_";
     result << "targetDevice=" << targetName << "_";
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void BatchToSpaceLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/comparison.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/comparison.cpp
@@ -34,7 +34,13 @@ std::string ComparisonLayerTest::getTestCaseName(testing::TestParamInfo<Comparis
     results << "secondInputType=" << secondInputType << "_";
     results << "netPRC=" << netPrecision.name() << "_";
     results << "targetDevice=" << targetName;
-    return results.str();
+    auto string = results.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ComparisonLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/concat.cpp
@@ -31,7 +31,13 @@ std::string ConcatLayerTest::getTestCaseName(const testing::TestParamInfo<concat
     result << "axis=" << axis << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetName << "_";
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ConcatLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convert.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convert.cpp
@@ -25,7 +25,13 @@ std::string ConvertLayerTest::getTestCaseName(const testing::TestParamInfo<Conve
     result << "targetPRC=" << targetPrecision.name() << "_";
     result << "inputPRC=" << inputPrecision.name() << "_";
     result << "targetDevice=" << targetName;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ConvertLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution.cpp
@@ -43,7 +43,13 @@ std::string ConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<convLay
     result << "AP=" << padType << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ConvolutionLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/convolution_backprop_data.cpp
@@ -43,7 +43,13 @@ std::string ConvolutionBackpropDataLayerTest::getTestCaseName(testing::TestParam
     result << "AP=" << padType << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ConvolutionBackpropDataLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/depth_to_space.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/depth_to_space.cpp
@@ -48,7 +48,13 @@ std::string DepthToSpaceLayerTest::getTestCaseName(const testing::TestParamInfo<
     result << "M=" << DepthToSpaceModeToString(mode) << "_";
     result << "BS=" << blockSize << "_";
     result << "targetDevice=" << targetName << "_";
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void DepthToSpaceLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/eltwise.cpp
@@ -45,7 +45,13 @@ std::string EltwiseLayerTest::getTestCaseName(testing::TestParamInfo<EltwiseTest
     results << "opType=" << opType << "_";
     results << "netPRC=" << netPrecision.name() << "_";
     results << "targetDevice=" << targetName;
-    return results.str();
+    auto string = results.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void EltwiseLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/equal.cpp
@@ -30,8 +30,13 @@ std::string EqualLayerTest::getTestCaseName(const testing::TestParamInfo<EqualTe
     result << "inPrc=" << inPrecision.name() << "_";
     result << "outPrc=" << outPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void EqualLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/fake_quantize.cpp
@@ -36,7 +36,13 @@ std::string FakeQuantizeLayerTest::getTestCaseName(testing::TestParamInfo<fqLaye
     result << "LEVELS=" << levels << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void FakeQuantizeLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/greater.cpp
@@ -30,8 +30,13 @@ std::string GreaterLayerTest::getTestCaseName(const testing::TestParamInfo<Great
     result << "inPrc=" << inPrecision.name() << "_";
     result << "outPrc=" << outPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void GreaterLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/grn.cpp
@@ -39,7 +39,13 @@ std::string GrnLayerTest::getTestCaseName(const testing::TestParamInfo<grnParams
     result << "netPRC=" << netPrecision.name() << separator;
     result << "bias="   << bias << separator;
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void GrnLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution.cpp
@@ -44,7 +44,13 @@ std::string GroupConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<gr
     result << "AP=" << padType << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void GroupConvolutionLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution_backprop_data.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/group_convolution_backprop_data.cpp
@@ -44,7 +44,13 @@ std::string GroupConvBackpropDataLayerTest::getTestCaseName(testing::TestParamIn
     result << "AP=" << padType << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void GroupConvBackpropDataLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/lrn.cpp
@@ -31,8 +31,13 @@ std::string LrnLayerTest::getTestCaseName(testing::TestParamInfo<lrnLayerTestPar
     result << "Axes=" << CommonTestUtils::vec2str(axes) << separator;
     result << "netPRC=" << netPrecision.name() << separator;
     result << "targetDevice=" << targetDevice;
-
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void LrnLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/mvn.cpp
@@ -41,7 +41,13 @@ std::string MvnLayerTest::getTestCaseName(testing::TestParamInfo<mvnParams> obj)
             result << "configItem=" << configItem.first << "_" << configItem.second << "_";
         }
     }
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void MvnLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/pooling.cpp
@@ -57,7 +57,13 @@ std::string PoolingLayerTest::getTestCaseName(testing::TestParamInfo<poolLayerTe
     result << "AutoPad=" << padType << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 std::string GlobalPoolingLayerTest::getTestCaseName(testing::TestParamInfo<globalPoolLayerTestParamsSet> obj) {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/reshape.cpp
@@ -28,7 +28,13 @@ namespace LayerTestsDefinitions {
     result << "specialZero=" << specialZero << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void ReshapeLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/select.cpp
@@ -33,7 +33,13 @@ namespace LayerTestsDefinitions {
         result << "_ELSE=" << dataType.name() << "_" << CommonTestUtils::vec2str(dataShapes[ELSE]);
         result << "_" << broadcast.m_type;
         result << "_targetDevice=" << targetDevice;
-        return result.str();
+        auto string = result.str();
+        std::replace(string.begin(), string.end(), '-', '_');
+        std::replace(string.begin(), string.end(), '.', '_');
+        std::replace(string.begin(), string.end(), '(', '_');
+        std::replace(string.begin(), string.end(), ')', '_');
+        std::replace(string.begin(), string.end(), '=', '_');
+        return string;
     }
 
     void SelectLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/softmax.cpp
@@ -37,7 +37,13 @@ std::string SoftMaxLayerTest::getTestCaseName(testing::TestParamInfo<softMaxLaye
     result << "axis=" << axis << "_";
     result << "targetDevice=" << targetDevice;
 
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void SoftMaxLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_depth.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/space_to_depth.cpp
@@ -48,7 +48,13 @@ std::string SpaceToDepthLayerTest::getTestCaseName(const testing::TestParamInfo<
     result << "M=" << SpaceToDepthModeToString(mode) << "_";
     result << "BS=" << blockSize << "_";
     result << "targetDevice=" << targetName << "_";
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void SpaceToDepthLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/split.cpp
@@ -34,7 +34,13 @@ std::string SplitLayerTest::getTestCaseName(testing::TestParamInfo<splitParams> 
     result << "IS";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void SplitLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/strided_slice.cpp
@@ -38,7 +38,13 @@ std::string StridedSliceLayerTest::getTestCaseName(const testing::TestParamInfo<
     result << "shrink_m=" << (params.shrinkAxisMask.empty() ? "def" : CommonTestUtils::vec2str(params.shrinkAxisMask)) << "_";
     result << "ellipsis_m=" << (params.ellipsisAxisMask.empty() ? "def" : CommonTestUtils::vec2str(params.ellipsisAxisMask)) << "_";
     result << "targetDevice=" << targetName;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void StridedSliceLayerTest::SetUp() {

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/transpose.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/transpose.cpp
@@ -29,7 +29,13 @@ std::string TransposeLayerTest::getTestCaseName(testing::TestParamInfo<transpose
     result << "inputOrder=" << CommonTestUtils::vec2str(inputOrder) << "_";
     result << "netPRC=" << netPrecision.name() << "_";
     result << "targetDevice=" << targetDevice;
-    return result.str();
+    auto string = result.str();
+    std::replace(string.begin(), string.end(), '-', '_');
+    std::replace(string.begin(), string.end(), '.', '_');
+    std::replace(string.begin(), string.end(), '(', '_');
+    std::replace(string.begin(), string.end(), ')', '_');
+    std::replace(string.begin(), string.end(), '=', '_');
+    return string;
 }
 
 void TransposeLayerTest::SetUp() {

--- a/inference-engine/tests/ie_test_utils/common_test_utils/test_constants.hpp
+++ b/inference-engine/tests/ie_test_utils/common_test_utils/test_constants.hpp
@@ -14,6 +14,7 @@ const char DEVICE_MYRIAD[] = "MYRIAD";
 const char DEVICE_KEEMBAY[] = "KMB";
 const char DEVICE_MULTI[] = "MULTI";
 const char DEVICE_HETERO[] = "HETERO";
+const char DEVICE_PLAIDML[] = "PlaidML";
 
 #ifdef _WIN32
     #ifdef __MINGW32__

--- a/ngraph/test/runtime/interpreter/int_executable.hpp
+++ b/ngraph/test/runtime/interpreter/int_executable.hpp
@@ -93,7 +93,7 @@
 #include "ngraph/runtime/tensor.hpp"
 #include "ngraph/state/bernoulli_rng_state.hpp"
 #include "ngraph/state/uniform_rng_state.hpp"
-#include "op/avg_pool.hpp"
+#include "ngraph/test/runtime/op/avg_pool.hpp"
 
 namespace ngraph
 {


### PR DESCRIPTION
Move forward PlaidML-specific changes from OpenVINO 2020.2 to OpenVINO master that are still required. Does not include new single_layer_tests that have not yet been incorporated into OV. Note that I have created a new branch, `plaidml-ov-2020.2` to match where the `plaidml` repo used to point in case anyone needs access to the 2020.2 version of this code in the future.

I also create a branch `plaidml-temp` at the commit from OV master I based this work on, to make this PR clear. My plan, unless review suggests I should take a different approach, is to land this PR onto `plaidml-temp`, then force-move the `plaidml` branch onto `plaidml-temp` and delete the temp branch.