### PR TITLE
Remove unused variable

### DIFF
--- a/ngraph/test/runtime/interpreter/int_executable.hpp
+++ b/ngraph/test/runtime/interpreter/int_executable.hpp
@@ -549,7 +549,6 @@ protected:
             const op::EmbeddingSegmentsSum* embed =
                 static_cast<const op::EmbeddingSegmentsSum*>(&node);
             auto indicesType = embed->input(1).get_element_type();
-            size_t indices_num = shape_size(embed->get_input_shape(1));
 
             if (indicesType == element::u64 || indicesType == element::i64)
             {


### PR DESCRIPTION
An additional fix needed to allow PlaidML to compile with warnings. See also the CI of https://github.com/plaidml/plaidml/pull/1294