### PR TITLE
Make separate PlaidMLProgramBuilder

### DIFF
--- a/inference-engine/src/plaidml_plugin/plaidml_executable_network.cpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_executable_network.cpp
@@ -9,13 +9,8 @@
 
 #include <vector>
 
-#include "details/ie_cnn_network_tools.h"
-
-#include "plaidml/op/op.h"
-
 #include "plaidml_infer_request.hpp"
-#include "plaidml_ops.hpp"
-#include "plaidml_util.hpp"
+#include "plaidml_program_builder.hpp"
 
 using namespace plaidml;          // NOLINT[build/namespaces]
 using namespace InferenceEngine;  // NOLINT[build/namespaces]
@@ -27,94 +22,9 @@ InferRequestInternal::Ptr PlaidMLExecutableNetwork::CreateInferRequestImpl(Input
   return std::make_shared<PlaidMLInferRequest>(networkInputs, networkOutputs, program_);
 }
 
-// TODO: need to move out of this class
-Program PlaidMLExecutableNetwork::TODOMakeProgram(std::shared_ptr<const ngraph::Function> fcn, InputsDataMap networkInputs, OutputsDataMap networkOutputs) {
-  IE_ASSERT(fcn);  // PlaidML requires that the nGraph-based API be used
-  for (const std::shared_ptr<ngraph::Node>& node : fcn->get_ordered_ops()) {
-    // TODO: Clean up how these cases are selected
-    if (node->description() == "Constant") {
-      handleConstant(node);
-    } else if (node->description() == "Parameter") {
-      handleParameter(node);
-    } else if (node->description() == "Result") {
-      handleOutput(node);
-    } else {
-      handleOp(node);
-    }
-  }
-
-  std::vector<edsl::Tensor> inputs;
-  for (const auto& kvp : networkInputs) {
-    inputs.push_back(tensorIONameMap_.at(kvp.first));
-  }
-  std::vector<edsl::Tensor> outputs;
-  for (const auto& kvp : networkOutputs) {
-    outputs.push_back(tensorIONameMap_.at(kvp.first));
-  }
-  return edsl::buildProgram("ie", inputs, outputs);
-}
-
 PlaidMLExecutableNetwork::PlaidMLExecutableNetwork(const ICNNNetwork& network, const std::string& device)
-    : todo_parts(network), program_(TODOMakeProgram(todo_parts.fcn, todo_parts.networkInputs, todo_parts.networkOutputs)) {
+    : program_(makePlaidMLProgram(network)) {
   program_.compile();
-}
-
-void PlaidMLExecutableNetwork::handleConstant(const std::shared_ptr<ngraph::Node>& node) {
-  IE_ASSERT(node->get_output_size() == 1);
-  IE_ASSERT(node->description() == "Constant");
-  auto type = to_plaidml(node->get_element_type());
-  std::vector<int64_t> dims{node->get_shape().begin(), node->get_shape().end()};
-  TensorShape shape(type, dims);
-  Buffer buffer(shape);
-  Context ctx{node.get()};
-  auto* layer = dynamic_cast<ngraph::opset1::Constant*>(ctx.layer);
-  buffer.copy_from(layer->get_data_ptr());
-  auto tensor = edsl::Constant(buffer, node->get_friendly_name());
-  tensorMap_[std::make_pair(node->get_name(), 0)] = tensor;
-}
-
-void PlaidMLExecutableNetwork::handleParameter(const std::shared_ptr<ngraph::Node>& node) {
-  IE_ASSERT(node->get_output_size() == 1);
-  std::vector<int64_t> dims{node->get_shape().begin(), node->get_shape().end()};
-  auto type = to_plaidml(node->get_element_type());
-  auto tensor = edsl::Placeholder(type, dims, node->get_friendly_name());
-  tensorMap_[std::make_pair(node->get_name(), 0)] = tensor;
-  tensorIONameMap_[node->get_friendly_name()] = tensor;
-}
-
-void PlaidMLExecutableNetwork::handleOutput(const std::shared_ptr<ngraph::Node>& node) {
-  // The OV output name is the name of the node _prior_ to the result
-  // When there are multiple outputs, it has .# appended, where # is the output index
-  const auto& src_output = node->input(0).get_source_output();
-  const auto& src_node = src_output.get_node();
-  std::string name = src_node->get_friendly_name();
-  if (src_node->get_output_size() > 1) {
-    name += "." + std::to_string(src_output.get_index());
-  }
-  tensorIONameMap_[name] = tensorMap_.at(std::make_pair(src_node->get_name(), src_output.get_index()));
-}
-
-void PlaidMLExecutableNetwork::handleOp(const std::shared_ptr<ngraph::Node>& node) {
-  auto op = OpsRegistry::instance()->resolve(node->description());
-  if (!op) {
-    THROW_IE_EXCEPTION << "Unsupported operation: " << node->description();
-  }
-
-  Context ctx{node.get()};
-  for (const auto& input : node->inputs()) {
-    const auto& src_output = input.get_source_output();
-    const auto& name = src_output.get_node()->get_name();
-    const auto& index = src_output.get_index();
-    auto tensor = tensorMap_.at(std::make_pair(name, index));
-    ctx.operands.push_back(tensor);
-  }
-  auto value = op(ctx);
-  auto tuple = value.as_tuple();
-  IE_ASSERT(tuple.size() == node->get_output_size());
-  for (unsigned i = 0; i < tuple.size(); i++) {
-    auto tensor = tuple.at(i).as_tensor();
-    tensorMap_[std::make_pair(node->get_name(), i)] = tensor;
-  }
 }
 
 void PlaidMLExecutableNetwork::GetMetric(const std::string& name, Parameter& result, ResponseDesc* resp) const {

--- a/inference-engine/src/plaidml_plugin/plaidml_executable_network.hpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_executable_network.hpp
@@ -4,30 +4,13 @@
 
 #pragma once
 
-#include <map>
-#include <memory>
 #include <string>
-#include <utility>
 
 #include "cpp_interfaces/impl/ie_executable_network_thread_safe_default.hpp"
-
-#include "ngraph/descriptor/tensor.hpp"
-
-#include "ngraph/function.hpp"  // TODO
 
 #include "plaidml/edsl/edsl.h"
 
 namespace PlaidMLPlugin {
-
-struct TODOnGraphParts {
-  std::shared_ptr<const ngraph::Function> fcn;
-  InferenceEngine::InputsDataMap networkInputs;
-  InferenceEngine::OutputsDataMap networkOutputs;
-  TODOnGraphParts(const InferenceEngine::ICNNNetwork& network) : fcn(network.getFunction()) {
-    network.getInputsInfo(networkInputs);
-    network.getOutputsInfo(networkOutputs);
-  }
-};
 
 class PlaidMLExecutableNetwork : public InferenceEngine::ExecutableNetworkThreadSafeDefault {
  public:
@@ -43,26 +26,6 @@ class PlaidMLExecutableNetwork : public InferenceEngine::ExecutableNetworkThread
                  InferenceEngine::ResponseDesc* resp) const override;
 
  private:
-  void handleConstant(const std::shared_ptr<ngraph::Node>& node);
-  void handleParameter(const std::shared_ptr<ngraph::Node>& node);
-  void handleOutput(const std::shared_ptr<ngraph::Node>& node);
-  void handleOp(const std::shared_ptr<ngraph::Node>& node);
-
-  plaidml::Program TODOMakeProgram(
-      std::shared_ptr<const ngraph::Function> fcn,
-      InferenceEngine::InputsDataMap networkInputs,
-      InferenceEngine::OutputsDataMap networkOutputs);
-
- private:
-  // Lets us look up the PlaidML tensor by the name of the node that produces it and the index of which output it is
-  std::map<std::pair<std::string, size_t>, plaidml::edsl::Tensor> tensorMap_;
-
-  // Go from the names OV uses for a networks inputs and outputs to the corresponding PlaidML Tensor
-  std::map<std::string, plaidml::edsl::Tensor> tensorIONameMap_;
-
-  // The inputs & outputs maps & Function, read from the nGraph graph at construction
-  TODOnGraphParts todo_parts;
-
   plaidml::Program program_;
 };
 

--- a/inference-engine/src/plaidml_plugin/plaidml_executable_network.hpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_executable_network.hpp
@@ -13,9 +13,21 @@
 
 #include "ngraph/descriptor/tensor.hpp"
 
+#include "ngraph/function.hpp"  // TODO
+
 #include "plaidml/edsl/edsl.h"
 
 namespace PlaidMLPlugin {
+
+struct TODOnGraphParts {
+  std::shared_ptr<const ngraph::Function> fcn;
+  InferenceEngine::InputsDataMap networkInputs;
+  InferenceEngine::OutputsDataMap networkOutputs;
+  TODOnGraphParts(const InferenceEngine::ICNNNetwork& network) : fcn(network.getFunction()) {
+    network.getInputsInfo(networkInputs);
+    network.getOutputsInfo(networkOutputs);
+  }
+};
 
 class PlaidMLExecutableNetwork : public InferenceEngine::ExecutableNetworkThreadSafeDefault {
  public:
@@ -36,12 +48,22 @@ class PlaidMLExecutableNetwork : public InferenceEngine::ExecutableNetworkThread
   void handleOutput(const std::shared_ptr<ngraph::Node>& node);
   void handleOp(const std::shared_ptr<ngraph::Node>& node);
 
+  plaidml::Program TODOMakeProgram(
+      std::shared_ptr<const ngraph::Function> fcn,
+      InferenceEngine::InputsDataMap networkInputs,
+      InferenceEngine::OutputsDataMap networkOutputs);
+
  private:
   // Lets us look up the PlaidML tensor by the name of the node that produces it and the index of which output it is
   std::map<std::pair<std::string, size_t>, plaidml::edsl::Tensor> tensorMap_;
 
   // Go from the names OV uses for a networks inputs and outputs to the corresponding PlaidML Tensor
   std::map<std::string, plaidml::edsl::Tensor> tensorIONameMap_;
+
+  // The inputs & outputs maps & Function, read from the nGraph graph at construction
+  TODOnGraphParts todo_parts;
+
+  plaidml::Program program_;
 };
 
 }  // namespace PlaidMLPlugin

--- a/inference-engine/src/plaidml_plugin/plaidml_program_builder.cpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_program_builder.cpp
@@ -21,16 +21,19 @@ PlaidMLProgramBuilder::PlaidMLProgramBuilder(const InferenceEngine::ICNNNetwork&
 }
 
 Program PlaidMLProgramBuilder::program() {
-  for (const std::shared_ptr<ngraph::Node>& node : fcn_->get_ordered_ops()) {
-    if (node->description() == "Constant") {
-      handleConstant(node);
-    } else if (node->description() == "Parameter") {
-      handleParameter(node);
-    } else if (node->description() == "Result") {
-      handleOutput(node);
-    } else {
-      handleOp(node);
+  if (!graph_parsed) {
+    for (const std::shared_ptr<ngraph::Node>& node : fcn_->get_ordered_ops()) {
+      if (node->description() == "Constant") {
+        handleConstant(node);
+      } else if (node->description() == "Parameter") {
+        handleParameter(node);
+      } else if (node->description() == "Result") {
+        handleOutput(node);
+      } else {
+        handleOp(node);
+      }
     }
+    graph_parsed = true;
   }
 
   std::vector<edsl::Tensor> inputs;

--- a/inference-engine/src/plaidml_plugin/plaidml_program_builder.cpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_program_builder.cpp
@@ -1,0 +1,109 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_program_builder.hpp"
+
+#include <vector>
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+using namespace plaidml;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+PlaidMLProgramBuilder::PlaidMLProgramBuilder(const InferenceEngine::ICNNNetwork& network)
+    : fcn_(network.getFunction()) {
+  IE_ASSERT(fcn_);  // PlaidML requires that the nGraph-based API be used
+  network.getInputsInfo(networkInputs_);
+  network.getOutputsInfo(networkOutputs_);
+}
+
+Program PlaidMLProgramBuilder::program() {
+  for (const std::shared_ptr<ngraph::Node>& node : fcn_->get_ordered_ops()) {
+    if (node->description() == "Constant") {
+      handleConstant(node);
+    } else if (node->description() == "Parameter") {
+      handleParameter(node);
+    } else if (node->description() == "Result") {
+      handleOutput(node);
+    } else {
+      handleOp(node);
+    }
+  }
+
+  std::vector<edsl::Tensor> inputs;
+  for (const auto& kvp : networkInputs_) {
+    inputs.push_back(tensorIONameMap_.at(kvp.first));
+  }
+  std::vector<edsl::Tensor> outputs;
+  for (const auto& kvp : networkOutputs_) {
+    outputs.push_back(tensorIONameMap_.at(kvp.first));
+  }
+  return edsl::buildProgram("ie", inputs, outputs);
+}
+
+void PlaidMLProgramBuilder::handleConstant(const std::shared_ptr<ngraph::Node>& node) {
+  IE_ASSERT(node->get_output_size() == 1);
+  IE_ASSERT(node->description() == "Constant");
+  auto type = to_plaidml(node->get_element_type());
+  std::vector<int64_t> dims{node->get_shape().begin(), node->get_shape().end()};
+  TensorShape shape(type, dims);
+  Buffer buffer(shape);
+  Context ctx{node.get()};
+  auto* layer = dynamic_cast<ngraph::opset1::Constant*>(ctx.layer);
+  buffer.copy_from(layer->get_data_ptr());
+  auto tensor = edsl::Constant(buffer, node->get_friendly_name());
+  tensorMap_[std::make_pair(node->get_name(), 0)] = tensor;
+}
+
+void PlaidMLProgramBuilder::handleParameter(const std::shared_ptr<ngraph::Node>& node) {
+  IE_ASSERT(node->get_output_size() == 1);
+  std::vector<int64_t> dims{node->get_shape().begin(), node->get_shape().end()};
+  auto type = to_plaidml(node->get_element_type());
+  auto tensor = edsl::Placeholder(type, dims, node->get_friendly_name());
+  tensorMap_[std::make_pair(node->get_name(), 0)] = tensor;
+  tensorIONameMap_[node->get_friendly_name()] = tensor;
+}
+
+void PlaidMLProgramBuilder::handleOutput(const std::shared_ptr<ngraph::Node>& node) {
+  // The OV output name is the name of the node _prior_ to the result
+  // When there are multiple outputs, it has .# appended, where # is the output index
+  const auto& src_output = node->input(0).get_source_output();
+  const auto& src_node = src_output.get_node();
+  std::string name = src_node->get_friendly_name();
+  if (src_node->get_output_size() > 1) {
+    name += "." + std::to_string(src_output.get_index());
+  }
+  tensorIONameMap_[name] = tensorMap_.at(std::make_pair(src_node->get_name(), src_output.get_index()));
+}
+
+void PlaidMLProgramBuilder::handleOp(const std::shared_ptr<ngraph::Node>& node) {
+  auto op = OpsRegistry::instance()->resolve(node->description());
+  if (!op) {
+    THROW_IE_EXCEPTION << "Unsupported operation: " << node->description();
+  }
+
+  Context ctx{node.get()};
+  for (const auto& input : node->inputs()) {
+    const auto& src_output = input.get_source_output();
+    const auto& name = src_output.get_node()->get_name();
+    const auto& index = src_output.get_index();
+    auto tensor = tensorMap_.at(std::make_pair(name, index));
+    ctx.operands.push_back(tensor);
+  }
+  auto value = op(ctx);
+  auto tuple = value.as_tuple();
+  IE_ASSERT(tuple.size() == node->get_output_size());
+  for (unsigned i = 0; i < tuple.size(); i++) {
+    auto tensor = tuple.at(i).as_tensor();
+    tensorMap_[std::make_pair(node->get_name(), i)] = tensor;
+  }
+}
+
+Program makePlaidMLProgram(const InferenceEngine::ICNNNetwork& network) {
+  return PlaidMLProgramBuilder(network).program();
+}
+
+} // namespace PlaidMLPlugin

--- a/inference-engine/src/plaidml_plugin/plaidml_program_builder.hpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_program_builder.hpp
@@ -1,0 +1,44 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "ie_icnn_network.hpp"
+
+#include "ngraph/node.hpp"
+
+#include "plaidml/edsl/edsl.h"
+
+namespace PlaidMLPlugin {
+
+class PlaidMLProgramBuilder {
+ public:
+  PlaidMLProgramBuilder() = delete;
+  PlaidMLProgramBuilder(const InferenceEngine::ICNNNetwork& network);
+
+  plaidml::Program program();
+
+ private:
+  void handleConstant(const std::shared_ptr<ngraph::Node>& node);
+  void handleParameter(const std::shared_ptr<ngraph::Node>& node);
+  void handleOutput(const std::shared_ptr<ngraph::Node>& node);
+  void handleOp(const std::shared_ptr<ngraph::Node>& node);
+
+  std::shared_ptr<const ngraph::Function> fcn_;
+  InferenceEngine::InputsDataMap networkInputs_;
+  InferenceEngine::OutputsDataMap networkOutputs_;
+
+  // Lets us look up the PlaidML tensor by the name of the node that produces it and the index of which output it is
+  std::map<std::pair<std::string, size_t>, plaidml::edsl::Tensor> tensorMap_;
+
+  // Go from the names OV uses for a networks inputs and outputs to the corresponding PlaidML Tensor
+  std::map<std::string, plaidml::edsl::Tensor> tensorIONameMap_;
+};
+
+plaidml::Program makePlaidMLProgram(const InferenceEngine::ICNNNetwork& network);
+
+}  // namespace PlaidMLPlugin

--- a/inference-engine/src/plaidml_plugin/plaidml_program_builder.hpp
+++ b/inference-engine/src/plaidml_plugin/plaidml_program_builder.hpp
@@ -31,6 +31,7 @@ class PlaidMLProgramBuilder {
   std::shared_ptr<const ngraph::Function> fcn_;
   InferenceEngine::InputsDataMap networkInputs_;
   InferenceEngine::OutputsDataMap networkOutputs_;
+  bool graph_parsed = false;
 
   // Lets us look up the PlaidML tensor by the name of the node that produces it and the index of which output it is
   std::map<std::pair<std::string, size_t>, plaidml::edsl::Tensor> tensorMap_;


### PR DESCRIPTION
Make a `PlaidMLProgramBuilder` class that contains the code for creating a `plaidml::Program` from an `InferenceEngine::ICNNNetwork`. This sets us up to create Programs for OpenVINO outside the context of the current PlaidMLPlugin's `PlaidMLExecutableNetwork`