### PR TITLE
Add BinaryConvolution

### DIFF
--- a/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
@@ -30,23 +30,32 @@ static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
   }
 
   auto mode = layer->get_mode();
-  auto pad_value = layer->get_pad_value();
+  edsl::Tensor inputTensor, filterTensor;
+  if (mode ==
+      ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT) {
+    auto one = cast(edsl::Tensor(1.0), DType::FLOAT32);
+    auto minusOne = cast(edsl::Tensor(-1.0), DType::FLOAT32);
+    inputTensor = edsl::select(I == 0, minusOne, one);
+    filterTensor = edsl::select(F == 0, minusOne, one);
+  } else {
+    auto one = cast(edsl::Tensor(1.0), DType::FLOAT32);
+    auto zero = cast(edsl::Tensor(0.0), DType::FLOAT32);
+    inputTensor = edsl::select(I == 0, zero, one);
+    filterTensor = edsl::select(F == 0, zero, one);
+  }
+
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
-  auto result = op::convolution(I, F)
+  auto pad_value = layer->get_pad_value();
+  auto result = op::convolution(inputTensor, filterTensor)
                     .strides(strides)
                     .dilations(dilations)
                     .autopad_mode(autopad_mode)
                     .input_layout(plaidml::op::TensorLayout::NCX)
                     .filter_layout(plaidml::op::TensorLayout::KCX);
   if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
-    std::vector<int> padding;
-    for (auto pad : layer->get_pads_begin()) {
-      padding.push_back(pad);
-    }
-    for (auto pad : layer->get_pads_end()) {
-      padding.push_back(pad);
-    }
-    result.manual_padding(padding);
+    // WARNING: float pad value is passes here
+    int padding = pad_value;
+    result.manual_padding({padding});
   }
   return edsl::make_tuple(result);
 });

--- a/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
@@ -20,9 +20,18 @@ static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
   IE_ASSERT(ctx.operands.size() == 2);
   auto I = ctx.operands.at(0);
   auto F = ctx.operands.at(1);
+  std::vector<int> strides;
+  for (auto stride : layer->get_strides()) {
+    strides.push_back(stride);
+  }
+  std::vector<int> dilations;
+  for (auto dilation : layer->get_dilations()) {
+    dilations.push_back(dilation);
+  }
 
   auto mode = layer->get_mode();
   auto pad_value = layer->get_pad_value();
+  auto autopad_mode = to_plaidml(layer->get_auto_pad());
   auto result = op::convolution(I, F)
                     .strides(strides)
                     .dilations(dilations)

--- a/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
@@ -33,13 +33,13 @@ static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
   edsl::Tensor inputTensor, filterTensor;
   if (mode ==
       ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT) {
-    auto one = cast(edsl::Tensor(1.0), DType::FLOAT32);
-    auto minusOne = cast(edsl::Tensor(-1.0), DType::FLOAT32);
+    auto one = cast(edsl::Tensor(1.0), DType::INT32);
+    auto minusOne = cast(edsl::Tensor(-1.0), DType::INT32);
     inputTensor = edsl::select(I == 0, minusOne, one);
     filterTensor = edsl::select(F == 0, minusOne, one);
   } else {
-    auto one = cast(edsl::Tensor(1.0), DType::FLOAT32);
-    auto zero = cast(edsl::Tensor(0.0), DType::FLOAT32);
+    auto one = cast(edsl::Tensor(1.0), DType::INT32);
+    auto zero = cast(edsl::Tensor(0.0), DType::INT32);
     inputTensor = edsl::select(I == 0, zero, one);
     filterTensor = edsl::select(F == 0, zero, one);
   }
@@ -53,8 +53,7 @@ static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
                     .input_layout(plaidml::op::TensorLayout::NCX)
                     .filter_layout(plaidml::op::TensorLayout::KCX);
   if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
-    // WARNING: float pad value is passes here
-    int padding = pad_value;
+    int padding = static_cast<int>(pad_value);
     result.manual_padding({padding});
   }
   return edsl::make_tuple(result);

--- a/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
@@ -31,18 +31,13 @@ static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
 
   auto mode = layer->get_mode();
   edsl::Tensor input_tensor, filter_tensor;
-  if (mode ==
-      ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT) {
-    auto one = cast(edsl::Tensor(1), DType::INT32);
-    auto minus_one = cast(edsl::Tensor(-1), DType::INT32);
-    input_tensor = edsl::select(I == 0, minus_one, one);
-    filter_tensor = edsl::select(F == 0, minus_one, one);
-  } else {
-    auto one = cast(edsl::Tensor(1), DType::INT32);
-    auto zero = cast(edsl::Tensor(0), DType::INT32);
-    input_tensor = edsl::select(I == 0, zero, one);
-    filter_tensor = edsl::select(F == 0, zero, one);
-  }
+  IE_ASSERT(
+      mode ==
+      ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT);
+  auto one = cast(edsl::Tensor(1), DType::INT32);
+  auto minus_one = cast(edsl::Tensor(-1), DType::INT32);
+  input_tensor = edsl::select(I == 0, minus_one, one);
+  filter_tensor = edsl::select(F == 0, minus_one, one);
 
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
   auto pad_value = layer->get_pad_value();

--- a/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
@@ -1,0 +1,45 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+#include "plaidml_util.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset4.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;         // NOLINT[build/namespaces]
+using namespace InferenceEngine; // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
+  auto *layer = ngraph::as_type<ngraph::opset4::BinaryConvolution>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() == 2);
+  auto I = ctx.operands.at(0);
+  auto F = ctx.operands.at(1);
+
+  auto mode = layer->get_mode();
+  auto pad_value = layer->get_pad_value();
+  auto result = op::convolution(I, F)
+                    .strides(strides)
+                    .dilations(dilations)
+                    .autopad_mode(autopad_mode)
+                    .input_layout(plaidml::op::TensorLayout::NCX)
+                    .filter_layout(plaidml::op::TensorLayout::KCX);
+  if (autopad_mode == plaidml::op::AutoPadMode::EXPLICIT) {
+    std::vector<int> padding;
+    for (auto pad : layer->get_pads_begin()) {
+      padding.push_back(pad);
+    }
+    for (auto pad : layer->get_pads_end()) {
+      padding.push_back(pad);
+    }
+    result.manual_padding(padding);
+  }
+  return edsl::make_tuple(result);
+});
+
+} // namespace PlaidMLPlugin

--- a/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/binary_convolution.cpp
@@ -30,23 +30,23 @@ static OpRegistration reg("binaryconvolution", [](const Context &ctx) {
   }
 
   auto mode = layer->get_mode();
-  edsl::Tensor inputTensor, filterTensor;
+  edsl::Tensor input_tensor, filter_tensor;
   if (mode ==
       ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::XNOR_POPCOUNT) {
-    auto one = cast(edsl::Tensor(1.0), DType::INT32);
-    auto minusOne = cast(edsl::Tensor(-1.0), DType::INT32);
-    inputTensor = edsl::select(I == 0, minusOne, one);
-    filterTensor = edsl::select(F == 0, minusOne, one);
+    auto one = cast(edsl::Tensor(1), DType::INT32);
+    auto minus_one = cast(edsl::Tensor(-1), DType::INT32);
+    input_tensor = edsl::select(I == 0, minus_one, one);
+    filter_tensor = edsl::select(F == 0, minus_one, one);
   } else {
-    auto one = cast(edsl::Tensor(1.0), DType::INT32);
-    auto zero = cast(edsl::Tensor(0.0), DType::INT32);
-    inputTensor = edsl::select(I == 0, zero, one);
-    filterTensor = edsl::select(F == 0, zero, one);
+    auto one = cast(edsl::Tensor(1), DType::INT32);
+    auto zero = cast(edsl::Tensor(0), DType::INT32);
+    input_tensor = edsl::select(I == 0, zero, one);
+    filter_tensor = edsl::select(F == 0, zero, one);
   }
 
   auto autopad_mode = to_plaidml(layer->get_auto_pad());
   auto pad_value = layer->get_pad_value();
-  auto result = op::convolution(inputTensor, filterTensor)
+  auto result = op::convolution(input_tensor, filter_tensor)
                     .strides(strides)
                     .dilations(dilations)
                     .autopad_mode(autopad_mode)

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
@@ -1,0 +1,99 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "common_test_utils/test_constants.hpp"
+#include "single_layer_tests/binary_convolution.hpp"
+
+using LayerTestsDefinitions::BinaryConvolutionLayerTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    // InferenceEngine::Precision::FP16  // TODO: Not yet working
+};
+
+/* ============= 2D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels = {{3, 3}, {3, 5}};
+const std::vector<std::vector<size_t>> strides = {{1, 1}, {1, 3}};
+const std::vector<std::vector<ptrdiff_t>> padBegins = {{0, 0}, {0, 3}};
+const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0}, {0, 3}};
+const std::vector<std::vector<size_t>> dilations = {{1, 1}, {3, 1}};
+const std::vector<size_t> numOutChannels = {1, 5};
+const std::vector<ngraph::op::PadType> padTypes = {
+    ngraph::op::PadType::EXPLICIT,  //
+    ngraph::op::PadType::VALID      //
+};
+
+const auto conv2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels),                     //
+                                                             ::testing::ValuesIn(strides),                     //
+                                                             ::testing::ValuesIn(padBegins),                   //
+                                                             ::testing::ValuesIn(padEnds),                     //
+                                                             ::testing::ValuesIn(dilations),                   //
+                                                             ::testing::ValuesIn(numOutChannels),              //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+);
+const auto conv2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels),                       //
+                                                          ::testing::ValuesIn(strides),                       //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
+                                                          ::testing::ValuesIn(dilations),                     //
+                                                          ::testing::ValuesIn(numOutChannels),                //
+                                                          ::testing::Values(ngraph::op::PadType::VALID)       //
+);
+
+INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, BinaryConvolutionLayerTest,
+                        ::testing::Combine(conv2DParams_ExplicitPadding,                            //
+                                           ::testing::ValuesIn(netPrecisions),                      //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        BinaryConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution2D_AutoPadValid, BinaryConvolutionLayerTest,
+                        ::testing::Combine(conv2DParams_AutoPadValid,  //
+                                           ::testing::ValuesIn(netPrecisions),
+                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
+                        BinaryConvolutionLayerTest::getTestCaseName);
+/* ============= 3D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {3, 5, 3}};
+const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}, {0, 2, 0}};
+
+const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {1, 2, 1}};
+const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}, {1, 2, 1}};
+
+const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3d),                   //
+                                                             ::testing::ValuesIn(strides3d),                   //
+                                                             ::testing::ValuesIn(paddings3d),                  //
+                                                             ::testing::ValuesIn(paddings3d),                  //
+                                                             ::testing::ValuesIn(dilations3d),                 //
+                                                             ::testing::Values(5),                             //
+                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+);
+const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3d),                        //
+                                                          ::testing::ValuesIn(strides3d),                        //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+                                                          ::testing::ValuesIn(dilations3d),                      //
+                                                          ::testing::Values(5),                                  //
+                                                          ::testing::Values(ngraph::op::PadType::VALID)          //
+);
+
+INSTANTIATE_TEST_CASE_P(Convolution3D_ExplicitPadding, BinaryConvolutionLayerTest,
+                        ::testing::Combine(conv3DParams_ExplicitPadding,                                //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        BinaryConvolutionLayerTest::getTestCaseName);
+
+INSTANTIATE_TEST_CASE_P(Convolution3D_AutoPadValid, BinaryConvolutionLayerTest,
+                        ::testing::Combine(conv3DParams_AutoPadValid,                                   //
+                                           ::testing::ValuesIn(netPrecisions),                          //
+                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        BinaryConvolutionLayerTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
@@ -12,8 +12,8 @@ using LayerTestsDefinitions::BinaryConvolutionLayerTest;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::I32,
     InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16  // TODO: Not yet working
 };
 
 /* ============= 2D Convolution ============= */

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
@@ -36,7 +36,9 @@ const auto conv2DParams_ExplicitPadding = ::testing::Combine(
     ::testing::ValuesIn(dilations),      //
     ::testing::ValuesIn(numOutChannels), //
     ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
+    ::testing::Values(ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::
+                          XNOR_POPCOUNT),
+    ::testing::Values(0.0));
 const auto conv2DParams_AutoPadValid = ::testing::Combine(
     ::testing::ValuesIn(kernels),                      //
     ::testing::ValuesIn(strides),                      //
@@ -45,7 +47,9 @@ const auto conv2DParams_AutoPadValid = ::testing::Combine(
     ::testing::ValuesIn(dilations),                    //
     ::testing::ValuesIn(numOutChannels),               //
     ::testing::Values(ngraph::op::PadType::VALID),
-    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
+    ::testing::Values(ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::
+                          XNOR_POPCOUNT),
+    ::testing::Values(0.0));
 
 INSTANTIATE_TEST_CASE_P(
     Convolution2D_ExplicitPadding, BinaryConvolutionLayerTest,
@@ -80,16 +84,20 @@ const auto conv3DParams_ExplicitPadding = ::testing::Combine(
     ::testing::ValuesIn(dilations3d), //
     ::testing::Values(5),             //
     ::testing::Values(ngraph::op::PadType::EXPLICIT),
-    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
+    ::testing::Values(ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::
+                          XNOR_POPCOUNT),
+    ::testing::Values(0.0));
 const auto conv3DParams_AutoPadValid = ::testing::Combine(
     ::testing::ValuesIn(kernels3d),                       //
     ::testing::ValuesIn(strides3d),                       //
-    ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})), //
-    ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})), //
+    ::testing::Values(std::vector<ptrdiff_t>({0, 1, 0})), //
+    ::testing::Values(std::vector<ptrdiff_t>({0, 1, 0})), //
     ::testing::ValuesIn(dilations3d),                     //
     ::testing::Values(5),                                 //
     ::testing::Values(ngraph::op::PadType::VALID),
-    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
+    ::testing::Values(ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode::
+                          XNOR_POPCOUNT),
+    ::testing::Values(0.0));
 
 INSTANTIATE_TEST_CASE_P(
     Convolution3D_ExplicitPadding, BinaryConvolutionLayerTest,

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/binary_convolution.cpp
@@ -24,40 +24,47 @@ const std::vector<std::vector<ptrdiff_t>> padEnds = {{0, 0}, {0, 3}};
 const std::vector<std::vector<size_t>> dilations = {{1, 1}, {3, 1}};
 const std::vector<size_t> numOutChannels = {1, 5};
 const std::vector<ngraph::op::PadType> padTypes = {
-    ngraph::op::PadType::EXPLICIT,  //
-    ngraph::op::PadType::VALID      //
+    ngraph::op::PadType::EXPLICIT, //
+    ngraph::op::PadType::VALID     //
 };
 
-const auto conv2DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels),                     //
-                                                             ::testing::ValuesIn(strides),                     //
-                                                             ::testing::ValuesIn(padBegins),                   //
-                                                             ::testing::ValuesIn(padEnds),                     //
-                                                             ::testing::ValuesIn(dilations),                   //
-                                                             ::testing::ValuesIn(numOutChannels),              //
-                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
-);
-const auto conv2DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels),                       //
-                                                          ::testing::ValuesIn(strides),                       //
-                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
-                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0})),  //
-                                                          ::testing::ValuesIn(dilations),                     //
-                                                          ::testing::ValuesIn(numOutChannels),                //
-                                                          ::testing::Values(ngraph::op::PadType::VALID)       //
-);
+const auto conv2DParams_ExplicitPadding = ::testing::Combine(
+    ::testing::ValuesIn(kernels),        //
+    ::testing::ValuesIn(strides),        //
+    ::testing::ValuesIn(padBegins),      //
+    ::testing::ValuesIn(padEnds),        //
+    ::testing::ValuesIn(dilations),      //
+    ::testing::ValuesIn(numOutChannels), //
+    ::testing::Values(ngraph::op::PadType::EXPLICIT),
+    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
+const auto conv2DParams_AutoPadValid = ::testing::Combine(
+    ::testing::ValuesIn(kernels),                      //
+    ::testing::ValuesIn(strides),                      //
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0})), //
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0})), //
+    ::testing::ValuesIn(dilations),                    //
+    ::testing::ValuesIn(numOutChannels),               //
+    ::testing::Values(ngraph::op::PadType::VALID),
+    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_ExplicitPadding, BinaryConvolutionLayerTest,
-                        ::testing::Combine(conv2DParams_ExplicitPadding,                            //
-                                           ::testing::ValuesIn(netPrecisions),                      //
-                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
-                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
-                        BinaryConvolutionLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(
+    Convolution2D_ExplicitPadding, BinaryConvolutionLayerTest,
+    ::testing::Combine(conv2DParams_ExplicitPadding,       //
+                       ::testing::ValuesIn(netPrecisions), //
+                       ::testing::Values(std::vector<size_t>({1, 3, 30,
+                                                              30})),        //
+                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)), //
+    BinaryConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution2D_AutoPadValid, BinaryConvolutionLayerTest,
-                        ::testing::Combine(conv2DParams_AutoPadValid,  //
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(std::vector<size_t>({1, 3, 30, 30})),  //
-                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),     //
-                        BinaryConvolutionLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(
+    Convolution2D_AutoPadValid, BinaryConvolutionLayerTest,
+    ::testing::Combine(conv2DParams_AutoPadValid, //
+                       ::testing::ValuesIn(netPrecisions),
+                       ::testing::Values(std::vector<size_t>({1, 3, 30,
+                                                              30})),        //
+                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)), //
+    BinaryConvolutionLayerTest::getTestCaseName);
+
 /* ============= 3D Convolution ============= */
 const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {3, 5, 3}};
 const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}, {0, 2, 0}};
@@ -65,35 +72,41 @@ const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}, {0, 2, 0}};
 const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {1, 2, 1}};
 const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}, {1, 2, 1}};
 
-const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3d),                   //
-                                                             ::testing::ValuesIn(strides3d),                   //
-                                                             ::testing::ValuesIn(paddings3d),                  //
-                                                             ::testing::ValuesIn(paddings3d),                  //
-                                                             ::testing::ValuesIn(dilations3d),                 //
-                                                             ::testing::Values(5),                             //
-                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
-);
-const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3d),                        //
-                                                          ::testing::ValuesIn(strides3d),                        //
-                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
-                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
-                                                          ::testing::ValuesIn(dilations3d),                      //
-                                                          ::testing::Values(5),                                  //
-                                                          ::testing::Values(ngraph::op::PadType::VALID)          //
-);
+const auto conv3DParams_ExplicitPadding = ::testing::Combine(
+    ::testing::ValuesIn(kernels3d),   //
+    ::testing::ValuesIn(strides3d),   //
+    ::testing::ValuesIn(paddings3d),  //
+    ::testing::ValuesIn(paddings3d),  //
+    ::testing::ValuesIn(dilations3d), //
+    ::testing::Values(5),             //
+    ::testing::Values(ngraph::op::PadType::EXPLICIT),
+    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
+const auto conv3DParams_AutoPadValid = ::testing::Combine(
+    ::testing::ValuesIn(kernels3d),                       //
+    ::testing::ValuesIn(strides3d),                       //
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})), //
+    ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})), //
+    ::testing::ValuesIn(dilations3d),                     //
+    ::testing::Values(5),                                 //
+    ::testing::Values(ngraph::op::PadType::VALID),
+    ::testing::Values("xnor-popcount"), ::testing::Values(0.0));
 
-INSTANTIATE_TEST_CASE_P(Convolution3D_ExplicitPadding, BinaryConvolutionLayerTest,
-                        ::testing::Combine(conv3DParams_ExplicitPadding,                                //
-                                           ::testing::ValuesIn(netPrecisions),                          //
-                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
-                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
-                        BinaryConvolutionLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(
+    Convolution3D_ExplicitPadding, BinaryConvolutionLayerTest,
+    ::testing::Combine(conv3DParams_ExplicitPadding,       //
+                       ::testing::ValuesIn(netPrecisions), //
+                       ::testing::Values(std::vector<size_t>({1, 3, 10, 10,
+                                                              10})),        //
+                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)), //
+    BinaryConvolutionLayerTest::getTestCaseName);
 
-INSTANTIATE_TEST_CASE_P(Convolution3D_AutoPadValid, BinaryConvolutionLayerTest,
-                        ::testing::Combine(conv3DParams_AutoPadValid,                                   //
-                                           ::testing::ValuesIn(netPrecisions),                          //
-                                           ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
-                                           ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
-                        BinaryConvolutionLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(
+    Convolution3D_AutoPadValid, BinaryConvolutionLayerTest,
+    ::testing::Combine(conv3DParams_AutoPadValid,          //
+                       ::testing::ValuesIn(netPrecisions), //
+                       ::testing::Values(std::vector<size_t>({1, 3, 10, 10,
+                                                              10})),        //
+                       ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)), //
+    BinaryConvolutionLayerTest::getTestCaseName);
 
-}  // namespace
+} // namespace

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/binary_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/binary_convolution.hpp
@@ -13,14 +13,16 @@
 #include "ngraph_functions/builders.hpp"
 #include "ngraph_functions/utils/ngraph_helpers.hpp"
 
-// ! [test_convolution:definition]
+// ! [test_binary_convolution:definition]
 typedef std::tuple<InferenceEngine::SizeVector, // Kernel size
                    InferenceEngine::SizeVector, // Strides
                    std::vector<ptrdiff_t>,      // Pad begin
                    std::vector<ptrdiff_t>,      // Pad end
                    InferenceEngine::SizeVector, // Dilation
                    size_t,                      // Num out channels
-                   ngraph::op::PadType          // Padding type
+                   ngraph::op::PadType,         // Padding type
+                   ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode,
+                   float // Padding Value
                    >
     binConvSpecificParams;
 typedef std::tuple<binConvSpecificParams,

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/binary_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/binary_convolution.hpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "functional_test_utils/layer_test_utils.hpp"
+#include "ngraph_functions/builders.hpp"
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+// ! [test_convolution:definition]
+typedef std::tuple<InferenceEngine::SizeVector, // Kernel size
+                   InferenceEngine::SizeVector, // Strides
+                   std::vector<ptrdiff_t>,      // Pad begin
+                   std::vector<ptrdiff_t>,      // Pad end
+                   InferenceEngine::SizeVector, // Dilation
+                   size_t,                      // Num out channels
+                   ngraph::op::PadType          // Padding type
+                   >
+    binConvSpecificParams;
+typedef std::tuple<binConvSpecificParams,
+                   InferenceEngine::Precision,   // Net precision
+                   InferenceEngine::SizeVector,  // Input shapes
+                   LayerTestsUtils::TargetDevice // Device name
+                   >
+    binConvLayerTestParamsSet;
+namespace LayerTestsDefinitions {
+
+class BinaryConvolutionLayerTest
+    : public testing::WithParamInterface<binConvLayerTestParamsSet>,
+      virtual public LayerTestsUtils::LayerTestsCommon {
+public:
+  static std::string
+  getTestCaseName(testing::TestParamInfo<binConvLayerTestParamsSet> obj);
+
+protected:
+  void SetUp() override;
+};
+// ! [test_convolution:definition]
+
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/binary_convolution.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/binary_convolution.hpp
@@ -13,7 +13,6 @@
 #include "ngraph_functions/builders.hpp"
 #include "ngraph_functions/utils/ngraph_helpers.hpp"
 
-// ! [test_binary_convolution:definition]
 typedef std::tuple<InferenceEngine::SizeVector, // Kernel size
                    InferenceEngine::SizeVector, // Strides
                    std::vector<ptrdiff_t>,      // Pad begin
@@ -43,6 +42,5 @@ public:
 protected:
   void SetUp() override;
 };
-// ! [test_convolution:definition]
 
 } // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/binary_convolution.cpp
@@ -1,0 +1,73 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <tuple>
+#include <vector>
+#include <string>
+#include <memory>
+#include <functional>
+#include <functional_test_utils/skip_tests_config.hpp>
+
+#include "ie_core.hpp"
+
+#include "common_test_utils/common_utils.hpp"
+#include "functional_test_utils/blob_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
+#include "functional_test_utils/layer_test_utils.hpp"
+
+#include "single_layer_tests/binary_convolution.hpp"
+
+namespace LayerTestsDefinitions {
+
+std::string BinaryConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<binConvLayerTestParamsSet> obj) {
+  binConvSpecificParams binConvParams;
+  InferenceEngine::Precision netPrecision;
+  InferenceEngine::SizeVector inputShapes;
+  std::string targetDevice;
+  std::tie(binConvParams, netPrecision, inputShapes, targetDevice) = obj.param;
+  ngraph::op::PadType padType;
+  InferenceEngine::SizeVector kernel, stride, dilation;
+  std::vector<ptrdiff_t> padBegin, padEnd;
+  size_t binConvOutChannels;
+  std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels, padType) = binConvParams;
+
+  std::ostringstream result;
+  result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
+  result << "K" << CommonTestUtils::vec2str(kernel) << "_";
+  result << "S" << CommonTestUtils::vec2str(stride) << "_";
+  result << "PB" << CommonTestUtils::vec2str(padBegin) << "_";
+  result << "PE" << CommonTestUtils::vec2str(padEnd) << "_";
+  result << "D=" << CommonTestUtils::vec2str(dilation) << "_";
+  result << "O=" << binConvOutChannels << "_";
+  result << "AP=" << padType << "_";
+  result << "netPRC=" << netPrecision.name() << "_";
+  result << "targetDevice=" << targetDevice;
+  return result.str();
+}
+
+void ConvolutionLayerTest::SetUp() {
+  binConvSpecificParams binConvParams;
+  std::vector<size_t> inputShape;
+  auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
+  std::tie(binConvParams, netPrecision, inputShape, targetDevice) = this->GetParam();
+  ngraph::op::PadType padType;
+  InferenceEngine::SizeVector kernel, stride, dilation;
+  std::vector<ptrdiff_t> padBegin, padEnd;
+  size_t binConvOutChannels;
+  std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels, padType) = binConvParams;
+  auto ngPrc = FuncTestUtils::PrecisionUtils::binConvertIE2nGraphPrc(netPrecision);
+  auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+  auto paramOuts = ngraph::helpers::binConvert2OutputVector(
+      ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
+  auto binConv = std::dynamic_pointer_cast<ngraph::opset1::Convolution>(
+      ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
+                                       padEnd, dilation, padType, binConvOutChannels));
+  ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(binConv)};
+  function = std::make_shared<ngraph::Function>(results, params, "convolution");
+}
+
+TEST_P(BinaryConvolutionLayerTest, CompareWithRefs) {
+Run();
+}
+}  // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/binary_convolution.cpp
@@ -2,25 +2,26 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include <tuple>
-#include <vector>
-#include <string>
-#include <memory>
 #include <functional>
 #include <functional_test_utils/skip_tests_config.hpp>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "ie_core.hpp"
 
 #include "common_test_utils/common_utils.hpp"
 #include "functional_test_utils/blob_utils.hpp"
-#include "functional_test_utils/plugin_cache.hpp"
 #include "functional_test_utils/layer_test_utils.hpp"
+#include "functional_test_utils/plugin_cache.hpp"
 
 #include "single_layer_tests/binary_convolution.hpp"
 
 namespace LayerTestsDefinitions {
 
-std::string BinaryConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<binConvLayerTestParamsSet> obj) {
+std::string BinaryConvolutionLayerTest::getTestCaseName(
+    testing::TestParamInfo<binConvLayerTestParamsSet> obj) {
   binConvSpecificParams binConvParams;
   InferenceEngine::Precision netPrecision;
   InferenceEngine::SizeVector inputShapes;
@@ -30,7 +31,10 @@ std::string BinaryConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<b
   InferenceEngine::SizeVector kernel, stride, dilation;
   std::vector<ptrdiff_t> padBegin, padEnd;
   size_t binConvOutChannels;
-  std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels, padType) = binConvParams;
+  std::string mode;
+  float padValue;
+  std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels,
+           padType, mode, padValue) = binConvParams;
 
   std::ostringstream result;
   result << "IS=" << CommonTestUtils::vec2str(inputShapes) << "_";
@@ -49,25 +53,28 @@ std::string BinaryConvolutionLayerTest::getTestCaseName(testing::TestParamInfo<b
 void ConvolutionLayerTest::SetUp() {
   binConvSpecificParams binConvParams;
   std::vector<size_t> inputShape;
-  auto netPrecision   = InferenceEngine::Precision::UNSPECIFIED;
-  std::tie(binConvParams, netPrecision, inputShape, targetDevice) = this->GetParam();
+  auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
+  std::tie(binConvParams, netPrecision, inputShape, targetDevice) =
+      this->GetParam();
   ngraph::op::PadType padType;
   InferenceEngine::SizeVector kernel, stride, dilation;
   std::vector<ptrdiff_t> padBegin, padEnd;
   size_t binConvOutChannels;
-  std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels, padType) = binConvParams;
-  auto ngPrc = FuncTestUtils::PrecisionUtils::binConvertIE2nGraphPrc(netPrecision);
+  std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels,
+           padType) = binConvParams;
+  auto ngPrc =
+      FuncTestUtils::PrecisionUtils::binConvertIE2nGraphPrc(netPrecision);
   auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
   auto paramOuts = ngraph::helpers::binConvert2OutputVector(
       ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
   auto binConv = std::dynamic_pointer_cast<ngraph::opset1::Convolution>(
-      ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride, padBegin,
-                                       padEnd, dilation, padType, binConvOutChannels));
-  ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(binConv)};
+      ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride,
+                                       padBegin, padEnd, dilation, padType,
+                                       binConvOutChannels));
+  ngraph::ResultVector results{
+      std::make_shared<ngraph::opset1::Result>(binConv)};
   function = std::make_shared<ngraph::Function>(results, params, "convolution");
 }
 
-TEST_P(BinaryConvolutionLayerTest, CompareWithRefs) {
-Run();
-}
-}  // namespace LayerTestsDefinitions
+TEST_P(BinaryConvolutionLayerTest, CompareWithRefs) { Run(); }
+} // namespace LayerTestsDefinitions

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/binary_convolution.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/binary_convolution.cpp
@@ -31,7 +31,7 @@ std::string BinaryConvolutionLayerTest::getTestCaseName(
   InferenceEngine::SizeVector kernel, stride, dilation;
   std::vector<ptrdiff_t> padBegin, padEnd;
   size_t binConvOutChannels;
-  std::string mode;
+  ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode mode;
   float padValue;
   std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels,
            padType, mode, padValue) = binConvParams;
@@ -50,7 +50,7 @@ std::string BinaryConvolutionLayerTest::getTestCaseName(
   return result.str();
 }
 
-void ConvolutionLayerTest::SetUp() {
+void BinaryConvolutionLayerTest::SetUp() {
   binConvSpecificParams binConvParams;
   std::vector<size_t> inputShape;
   auto netPrecision = InferenceEngine::Precision::UNSPECIFIED;
@@ -60,12 +60,13 @@ void ConvolutionLayerTest::SetUp() {
   InferenceEngine::SizeVector kernel, stride, dilation;
   std::vector<ptrdiff_t> padBegin, padEnd;
   size_t binConvOutChannels;
+  ngraph::op::v1::BinaryConvolution::BinaryConvolutionMode mode;
+  float padValue;
   std::tie(kernel, stride, padBegin, padEnd, dilation, binConvOutChannels,
-           padType) = binConvParams;
-  auto ngPrc =
-      FuncTestUtils::PrecisionUtils::binConvertIE2nGraphPrc(netPrecision);
+           padType, mode, padValue) = binConvParams;
+  auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
   auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
-  auto paramOuts = ngraph::helpers::binConvert2OutputVector(
+  auto paramOuts = ngraph::helpers::convert2OutputVector(
       ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
   auto binConv = std::dynamic_pointer_cast<ngraph::opset1::Convolution>(
       ngraph::builder::makeConvolution(paramOuts[0], ngPrc, kernel, stride,
@@ -73,7 +74,8 @@ void ConvolutionLayerTest::SetUp() {
                                        binConvOutChannels));
   ngraph::ResultVector results{
       std::make_shared<ngraph::opset1::Result>(binConv)};
-  function = std::make_shared<ngraph::Function>(results, params, "convolution");
+  function =
+      std::make_shared<ngraph::Function>(results, params, "binaryconvolution");
 }
 
 TEST_P(BinaryConvolutionLayerTest, CompareWithRefs) { Run(); }


### PR DESCRIPTION
According to description in  [OpenVINO BinaryConvolution](https://docs.openvinotoolkit.org/latest/openvino_docs_ops_convolution_BinaryConvolution_1.html), strategy here is converting both input tensors to tensors filled with binary values(0/1, -1/1), and pass them to `plaidml::op::convolution`.
After testing, only `I32` and `FP32` can pass all test cases. It seems OpenVINO doc does not explicitly mention the datatype. 
So, if that's okay for this op, or should we make it works for binary datatype?
