### PR TITLE
Add extract image patches op

### DIFF
--- a/inference-engine/src/plaidml_plugin/ops/extract_image_patches.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/extract_image_patches.cpp
@@ -58,7 +58,7 @@ edsl::Tensor create_kernel_tensor(const int64_t &filter_row,
   TensorShape shape(input_type, kernel_dims);
   Buffer buffer(shape);
   buffer.copy_from(data.data());
-  return edsl::cast(edsl::Constant(buffer, "Kernel"), input_type);
+  return edsl::Constant(buffer, "Kernel");
 }
 
 } // namespace

--- a/inference-engine/src/plaidml_plugin/ops/extract_image_patches.cpp
+++ b/inference-engine/src/plaidml_plugin/ops/extract_image_patches.cpp
@@ -1,0 +1,43 @@
+// Copyright (C) 2020 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "plaidml_ops.hpp"
+
+#include "ngraph/opsets/opset.hpp"
+#include "ngraph/opsets/opset1.hpp"
+#include "ngraph/opsets/opset3.hpp"
+
+#include "plaidml/op/op.h"
+
+using namespace plaidml;          // NOLINT[build/namespaces]
+using namespace InferenceEngine;  // NOLINT[build/namespaces]
+
+namespace PlaidMLPlugin {
+
+static OpRegistration reg("ExtractImagePatches", [](const Context& ctx) {
+  auto* layer = ngraph::as_type<ngraph::opset3::ExtractImagePatches>(ctx.layer);
+  IE_ASSERT(ctx.operands.size() == 2);
+  auto I = ctx.operands.at(0);
+  // operands.at(1) is unused, just read the Constant instead
+  ngraph::Shape shape;
+  auto shape_ngraph_op = ngraph::as_type_ptr<ngraph::op::Constant>(layer->input_value(1).get_node_shared_ptr());
+  if (shape_ngraph_op) {
+    shape = shape_ngraph_op->get_shape_val();
+  } else {
+    THROW_IE_EXCEPTION << "Dynamic reshaping not currently supported by PlaidML plugin";
+  }
+
+  auto special_zero = layer->get_special_zero();
+  if (!special_zero) {
+    for (auto dim : shape) {
+      if (dim == 0) {
+        THROW_IE_EXCEPTION << "Cannot use size 0 dim in reshape with special_zero set to false";
+      }
+    }
+  }
+
+  return edsl::make_tuple(op::reshape(I, edsl::make_tuple<size_t>(shape)));
+});
+
+}  // namespace PlaidMLPlugin

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -11,27 +11,29 @@ using LayerTestsDefinitions::ExtractImagePatchesTest;
 namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
+    InferenceEngine::Precision::I32,
+//    InferenceEngine::Precision::FP32,
     // InferenceEngine::Precision::FP16  // TODO: Not yet working
 };
 
 /* ============= 2D Convolution ============= */
 const std::vector<std::vector<size_t>> kernels = {{3, 3}, {5, 5}};
-const std::vector<std::vector<size_t>> strides = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> strides = {{5, 5}, {1, 1}};
 const std::vector<std::vector<size_t>> rates = {{1, 1}, {2, 2}};
 const std::vector<ngraph::op::PadType> padTypes = {
-    ngraph::op::PadType::EXPLICIT,  //
-    ngraph::op::PadType::VALID      //
+    ngraph::op::PadType::VALID,       //
+    ngraph::op::PadType::SAME_UPPER,  //
+    ngraph::op::PadType::SAME_LOWER,  //
 };
 
-INSTANTIATE_TEST_CASE_P(ExtractImagePatches2DTestCheck, ExtractImagePatchesTest,
+INSTANTIATE_TEST_CASE_P(ExtractImagePatches2D_AutoTestCheck, ExtractImagePatchesTest,
                          ::testing::Combine(::testing::Values(std::vector<size_t>({1, 1, 10, 10})),    //
-                                            ::testing::ValuesIn(kernels),                                  //
-                                            ::testing::ValuesIn(strides),                                  //
-                                            ::testing::ValuesIn(rates),                                    //
-                                            ::testing::ValuesIn(padTypes),                                 //
-                                            ::testing::ValuesIn(netPrecisions),                          //
-                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                                            ::testing::ValuesIn(kernels),                              //
+                                            ::testing::ValuesIn(strides),                              //
+                                            ::testing::ValuesIn(rates),                                //
+                                            ::testing::ValuesIn(padTypes),             //
+                                            ::testing::ValuesIn(netPrecisions),                        //
+                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),       //
                         ExtractImagePatchesTest::getTestCaseName);
 
 //

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -12,11 +12,9 @@ namespace {
 
 const std::vector<InferenceEngine::Precision> netPrecisions = {
     InferenceEngine::Precision::I32,
-//    InferenceEngine::Precision::FP32,
-    // InferenceEngine::Precision::FP16  // TODO: Not yet working
+    InferenceEngine::Precision::FP32,
 };
 
-/* ============= 2D Convolution ============= */
 const std::vector<std::vector<size_t>> kernels = {{3, 3}, {5, 5}};
 const std::vector<std::vector<size_t>> strides = {{5, 5}, {1, 1}};
 const std::vector<std::vector<size_t>> rates = {{1, 1}, {2, 2}};
@@ -27,45 +25,13 @@ const std::vector<ngraph::op::PadType> padTypes = {
 };
 
 INSTANTIATE_TEST_CASE_P(ExtractImagePatches2D_AutoTestCheck, ExtractImagePatchesTest,
-                         ::testing::Combine(::testing::Values(std::vector<size_t>({1, 1, 10, 10})),    //
+                         ::testing::Combine(::testing::Values(std::vector<size_t>({1, 3, 10, 10})),    //
                                             ::testing::ValuesIn(kernels),                              //
                                             ::testing::ValuesIn(strides),                              //
                                             ::testing::ValuesIn(rates),                                //
-                                            ::testing::ValuesIn(padTypes),             //
+                                            ::testing::ValuesIn(padTypes),                             //
                                             ::testing::ValuesIn(netPrecisions),                        //
                                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),       //
                         ExtractImagePatchesTest::getTestCaseName);
-
-//
-///* ============= 3D Convolution ============= */
-//const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {3, 5, 3}};
-//const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}, {0, 2, 0}};
-//
-//const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {1, 2, 1}};
-//const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}, {1, 2, 1}};
-//
-//const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3d),                   //
-//                                                             ::testing::ValuesIn(strides3d),                   //
-//                                                             ::testing::ValuesIn(paddings3d),                  //
-//                                                             ::testing::ValuesIn(paddings3d),                  //
-//                                                             ::testing::ValuesIn(dilations3d),                 //
-//                                                             ::testing::Values(5),                             //
-//                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
-//);
-//const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3d),                        //
-//                                                          ::testing::ValuesIn(strides3d),                        //
-//                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
-//                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
-//                                                          ::testing::ValuesIn(dilations3d),                      //
-//                                                          ::testing::Values(5),                                  //
-//                                                          ::testing::Values(ngraph::op::PadType::VALID)          //
-//);
-//
-//INSTANTIATE_TEST_CASE_P(ExtractImagePatches3DTestCheck, ExtractImagePatchesTest,
-//                         ::testing::Combine(conv3DParams_ExplicitPadding,                                //
-//                                            ::testing::ValuesIn(netPrecisions),                          //
-//                                            ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
-//                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
-//                        ExtractImagePatchesTest::getTestCaseName);
 
 }  // namespace

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -25,11 +25,11 @@ const std::vector<ngraph::op::PadType> padTypes = {
 };
 
 INSTANTIATE_TEST_CASE_P(ExtractImagePatches2DTestCheck, ExtractImagePatchesTest,
-                         ::testing::Combine(::testing::Values(std::vector<size_t>({10, 10, 10, 10})),    //
-                                            ::testing::Values(kernels),                                  //
-                                            ::testing::Values(strides),                                  //
-                                            ::testing::Values(rates),                                    //
-                                            ::testing::Values(padTypes),                                 //
+                         ::testing::Combine(::testing::Values(std::vector<size_t>({1, 1, 10, 10})),    //
+                                            ::testing::ValuesIn(kernels),                                  //
+                                            ::testing::ValuesIn(strides),                                  //
+                                            ::testing::ValuesIn(rates),                                    //
+                                            ::testing::ValuesIn(padTypes),                                 //
                                             ::testing::ValuesIn(netPrecisions),                          //
                                             ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
                         ExtractImagePatchesTest::getTestCaseName);

--- a/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/plaidml/shared_tests_instances/single_layer_tests/extract_image_patches.cpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2019 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <vector>
+
+#include "single_layer_tests/extract_image_patches.hpp"
+
+using LayerTestsDefinitions::ExtractImagePatchesTest;
+
+namespace {
+
+const std::vector<InferenceEngine::Precision> netPrecisions = {
+    InferenceEngine::Precision::FP32,
+    // InferenceEngine::Precision::FP16  // TODO: Not yet working
+};
+
+/* ============= 2D Convolution ============= */
+const std::vector<std::vector<size_t>> kernels = {{3, 3}, {5, 5}};
+const std::vector<std::vector<size_t>> strides = {{1, 1}, {2, 2}};
+const std::vector<std::vector<size_t>> rates = {{1, 1}, {2, 2}};
+const std::vector<ngraph::op::PadType> padTypes = {
+    ngraph::op::PadType::EXPLICIT,  //
+    ngraph::op::PadType::VALID      //
+};
+
+INSTANTIATE_TEST_CASE_P(ExtractImagePatches2DTestCheck, ExtractImagePatchesTest,
+                         ::testing::Combine(::testing::Values(std::vector<size_t>({10, 10, 10, 10})),    //
+                                            ::testing::Values(kernels),                                  //
+                                            ::testing::Values(strides),                                  //
+                                            ::testing::Values(rates),                                    //
+                                            ::testing::Values(padTypes),                                 //
+                                            ::testing::ValuesIn(netPrecisions),                          //
+                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+                        ExtractImagePatchesTest::getTestCaseName);
+
+//
+///* ============= 3D Convolution ============= */
+//const std::vector<std::vector<size_t>> kernels3d = {{3, 3, 3}, {3, 5, 3}};
+//const std::vector<std::vector<ptrdiff_t>> paddings3d = {{0, 0, 0}, {0, 2, 0}};
+//
+//const std::vector<std::vector<size_t>> strides3d = {{1, 1, 1}, {1, 2, 1}};
+//const std::vector<std::vector<size_t>> dilations3d = {{1, 1, 1}, {1, 2, 1}};
+//
+//const auto conv3DParams_ExplicitPadding = ::testing::Combine(::testing::ValuesIn(kernels3d),                   //
+//                                                             ::testing::ValuesIn(strides3d),                   //
+//                                                             ::testing::ValuesIn(paddings3d),                  //
+//                                                             ::testing::ValuesIn(paddings3d),                  //
+//                                                             ::testing::ValuesIn(dilations3d),                 //
+//                                                             ::testing::Values(5),                             //
+//                                                             ::testing::Values(ngraph::op::PadType::EXPLICIT)  //
+//);
+//const auto conv3DParams_AutoPadValid = ::testing::Combine(::testing::ValuesIn(kernels3d),                        //
+//                                                          ::testing::ValuesIn(strides3d),                        //
+//                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+//                                                          ::testing::Values(std::vector<ptrdiff_t>({0, 0, 0})),  //
+//                                                          ::testing::ValuesIn(dilations3d),                      //
+//                                                          ::testing::Values(5),                                  //
+//                                                          ::testing::Values(ngraph::op::PadType::VALID)          //
+//);
+//
+//INSTANTIATE_TEST_CASE_P(ExtractImagePatches3DTestCheck, ExtractImagePatchesTest,
+//                         ::testing::Combine(conv3DParams_ExplicitPadding,                                //
+//                                            ::testing::ValuesIn(netPrecisions),                          //
+//                                            ::testing::Values(std::vector<size_t>({1, 3, 10, 10, 10})),  //
+//                                            ::testing::Values(CommonTestUtils::DEVICE_PLAIDML)),         //
+//                        ExtractImagePatchesTest::getTestCaseName);
+
+}  // namespace

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
@@ -18,17 +18,17 @@ namespace LayerTestsDefinitions {
 
 std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj) {
     std::vector<size_t> inputShape, kernel, strides, rates;
-    ngraph::op::PadType pad_type;
+    ngraph::op::PadType padType;
     InferenceEngine::Precision netPrc;
     std::string targetName;
-    std::tie(inputShape, kernel, strides, rates, pad_type, netPrc, targetName) = obj.param;
+    std::tie(inputShape, kernel, strides, rates, padType, netPrc, targetName) = obj.param;
     std::ostringstream result;
     result << "IS=" << CommonTestUtils::vec2str(inputShape) << "_";
     result << "netPRC=" << netPrc.name() << "_";
     result << "K=" << CommonTestUtils::vec2str(kernel) << "_";
     result << "S=" << CommonTestUtils::vec2str(strides) << "_";
     result << "R=" << CommonTestUtils::vec2str(rates) << "_";
-    result << "P=" << pad_type << "_";
+    result << "P=" << padType << "_";
     result << "targetDevice=" << targetName;
     return result.str();
 }
@@ -36,9 +36,9 @@ std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInf
 void ExtractImagePatchesTest::SetUp() {
   std::vector<size_t> inputShape;
   InferenceEngine::SizeVector kernel, strides, rates;
-  ngraph::op::PadType pad_type;
+  ngraph::op::PadType padType;
   InferenceEngine::Precision netPrecision;
-  std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision,
+  std::tie(inputShape, kernel, strides, rates, padType, netPrecision,
            targetDevice) = this->GetParam();
   auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
   auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShape});
@@ -46,7 +46,7 @@ void ExtractImagePatchesTest::SetUp() {
           ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
   auto extImgPatches = std::dynamic_pointer_cast<ngraph::opset3::ExtractImagePatches>(
           std::make_shared<ngraph::opset3::ExtractImagePatches>(paramOut[0], ngraph::Shape(kernel),
-                                                            ngraph::Strides(strides), ngraph::Shape(rates), pad_type));
+                                                            ngraph::Strides(strides), ngraph::Shape(rates), padType));
   ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(extImgPatches)};
   function = std::make_shared<ngraph::Function>(results, paramsIn, "ExtractImagePatches");
 }

--- a/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
+++ b/inference-engine/tests/functional/plugin/shared/src/single_layer_tests/extract_image_patches.cpp
@@ -14,7 +14,6 @@
 #include "functional_test_utils/layer_test_utils.hpp"
 #include "ngraph_functions/builders.hpp"
 
-
 namespace LayerTestsDefinitions {
 
 std::string ExtractImagePatchesTest::getTestCaseName(const testing::TestParamInfo<extractImagePatchesTuple> &obj) {
@@ -41,20 +40,15 @@ void ExtractImagePatchesTest::SetUp() {
   InferenceEngine::Precision netPrecision;
   std::tie(inputShape, kernel, strides, rates, pad_type, netPrecision,
            targetDevice) = this->GetParam();
-
   auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
   auto paramsIn = ngraph::builder::makeParams(ngPrc, {inputShape});
   auto paramOut = ngraph::helpers::convert2OutputVector(
-      ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
-  auto extImgPatches =
-      std::dynamic_pointer_cast<ngraph::opset3::ExtractImagePatches>(
-          std::make_shared<ngraph::opset3::ExtractImagePatches>(
-              paramOut[0], ngraph::Shape(kernel), ngraph::Strides(strides),
-              ngraph::Shape(rates), pad_type));
-  ngraph::ResultVector results{
-      std::make_shared<ngraph::opset1::Result>(extImgPatches)};
-  function = std::make_shared<ngraph::Function>(results, paramsIn,
-                                                "ExtractImagePatches");
+          ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(paramsIn));
+  auto extImgPatches = std::dynamic_pointer_cast<ngraph::opset3::ExtractImagePatches>(
+          std::make_shared<ngraph::opset3::ExtractImagePatches>(paramOut[0], ngraph::Shape(kernel),
+                                                            ngraph::Strides(strides), ngraph::Shape(rates), pad_type));
+  ngraph::ResultVector results{std::make_shared<ngraph::opset1::Result>(extImgPatches)};
+  function = std::make_shared<ngraph::Function>(results, paramsIn, "ExtractImagePatches");
 }
 
 TEST_P(ExtractImagePatchesTest, CompareWithRefs) {


### PR DESCRIPTION
using plaidml convolution op to implement extract image patches. According to openvino ExtractImagePatche op, it supports three kind of PadType(VALID, SAME_UPPER, SAME_LOWER), and INT32, FP32 input data Type. 