### PR TITLE
Onehot op header file cleanup.

### DIFF
--- a/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/one_hot.hpp
+++ b/inference-engine/tests/functional/plugin/shared/include/single_layer_tests/one_hot.hpp
@@ -14,7 +14,7 @@ using oneHotParams = typename std::tuple<
     float,                      // off_value
     std::vector<size_t>,        // Input shapes
     InferenceEngine::Precision, // Net precision
-    LayerTestsUtils::TargetDevice // Target device name                   >
+    LayerTestsUtils::TargetDevice // Target device name
     >;
 
 namespace LayerTestsDefinitions {


### PR DESCRIPTION
Clean "Stray whitespace and > at the end of this line" remained in PR [openvino#124](https://github.com/plaidml/openvino/pull/124).