### PR TITLE
Add input type option for prior_box_clustered.

### DIFF
--- a/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/plugin/gpu/shared_tests_instances/single_layer_tests/prior_box_clustered.cpp
@@ -46,6 +46,11 @@ const std::vector<bool> clips = {
     true, false
 };
 
+const std::vector<ngraph::helpers::InputLayerType> InputTypes = {
+  ngraph::helpers::InputLayerType::CONSTANT,
+  ngraph::helpers::InputLayerType::PARAMETER,
+};
+
 const auto layerSpeficParams = ::testing::Combine(
     ::testing::ValuesIn(widths),
     ::testing::ValuesIn(heights),
@@ -66,6 +71,7 @@ INSTANTIATE_TEST_CASE_P(smoke_PriorBoxClustered_Basic, PriorBoxClusteredLayerTes
                             ::testing::Values(InferenceEngine::Layout::ANY),
                             ::testing::Values(std::vector<size_t>({ 4, 4 })),
                             ::testing::Values(std::vector<size_t>({ 50, 50 })),
+                            ::testing::Values(InputTypes),
                             ::testing::Values(CommonTestUtils::DEVICE_GPU)),
                         PriorBoxClusteredLayerTest::getTestCaseName
 );

--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/prior_box_clustered.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/prior_box_clustered.hpp
@@ -47,6 +47,7 @@ typedef std::tuple<
         InferenceEngine::Layout,      // Output layout
         InferenceEngine::SizeVector,  // input shape
         InferenceEngine::SizeVector,  // image shape
+        ngraph::helpers::InputLayerType,  // input type
         std::string> priorBoxClusteredLayerParams;
 
 class PriorBoxClusteredLayerTest

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
@@ -98,6 +98,9 @@ void PriorBoxClusteredLayerTest::SetUp() {
           attributes);
     } else {
       auto inputPrc = ngraph::element::Type_t::i64;
+      if(inPrc != InferenceEngine::Precision::UNSPECIFIED) {
+        inputPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
+      }
       auto constInput1 = std::make_shared<ngraph::opset5::Constant>(
             inputPrc, ngraph::Shape{inputShapes.size()}, inputShapes);
       auto constInput2 = std::make_shared<ngraph::opset5::Constant>(


### PR DESCRIPTION
The test will create parameters based on input type.

Signed-off-by: xin1.wang <xin1.wang@intel.com>