### PR TITLE
Add input type option for ROIPooling

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/roi_pooling.hpp
+++ b/inference-engine/tests/functional/shared_test_classes/include/shared_test_classes/single_layer/roi_pooling.hpp
@@ -24,6 +24,7 @@ using roiPoolingParamsTuple = std::tuple<
         float,                                      // Spatial scale
         ngraph::helpers::ROIPoolingTypes,           // ROIPooling method
         InferenceEngine::Precision,                 // Net precision
+        ngraph::helpers::InputLayerType,            // Secondary input type
         LayerTestsUtils::TargetDevice>;             // Device name
 
 class ROIPoolingLayerTest : public testing::WithParamInterface<roiPoolingParamsTuple>,
@@ -34,9 +35,11 @@ public:
 
 protected:
     void SetUp() override;
+    void GenerateCoords(const std::vector<size_t> &feat_map_shape, float *buffer, size_t size);
 
 private:
     ngraph::helpers::ROIPoolingTypes pool_method;
+    ngraph::helpers::InputLayerType secondaryInputType;
     float spatial_scale;
 };
 

--- a/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
+++ b/inference-engine/tests/ngraph_helpers/ngraph_functions/include/ngraph_functions/builders.hpp
@@ -67,6 +67,24 @@ std::shared_ptr<Node> makeConstant(const element::Type &type, const std::vector<
     return weightsNode;
 }
 
+template <typename T>
+std::shared_ptr<ngraph::Node> makeInputLayer(const element::Type &type, ngraph::helpers::InputLayerType inputType,
+                                             const std::vector<size_t> &shape, const std::vector<T> &data) {
+    std::shared_ptr<ngraph::Node> input;
+    switch (inputType) {
+        case ngraph::helpers::InputLayerType::CONSTANT: {
+            input = ngraph::builder::makeConstant<T>(type, shape, data, false);
+            break;
+        }
+        case ngraph::helpers::InputLayerType::PARAMETER:
+            input = ngraph::builder::makeParams(type, {shape})[0];
+            break;
+        default:
+            throw std::runtime_error("Unsupported inputType");
+    }
+    return input;
+}
+
 std::shared_ptr<ngraph::Node> makeInputLayer(const element::Type& type, ngraph::helpers::InputLayerType inputType,
                                              const std::vector<size_t>& shape);
 


### PR DESCRIPTION
add input type for coordinate box(second input of `ROIPooling`). According to this type, we can make `coords` as `constant` node or `parameter` node. and, the different kind of those node will be filled with the same data which is generated by `GenerateCoords`.