### PR TITLE
Lint whitespace

### DIFF
--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/prior_box_clustered.cpp
@@ -89,7 +89,7 @@ void PriorBoxClusteredLayerTest::SetUp() {
     attributes.variances = variances;
 
     std::shared_ptr<ngraph::op::PriorBoxClustered> priorBoxClustered;
-    if(inputType == ngraph::helpers::InputLayerType::PARAMETER) {
+    if (inputType == ngraph::helpers::InputLayerType::PARAMETER) {
       auto shape_of_1 = std::make_shared<ngraph::opset3::ShapeOf>(params[0]);
       auto shape_of_2 = std::make_shared<ngraph::opset3::ShapeOf>(params[1]);
       priorBoxClustered = std::make_shared<ngraph::op::PriorBoxClustered>(
@@ -98,7 +98,7 @@ void PriorBoxClusteredLayerTest::SetUp() {
           attributes);
     } else {
       auto inputPrc = ngraph::element::Type_t::i64;
-      if(inPrc != InferenceEngine::Precision::UNSPECIFIED) {
+      if (inPrc != InferenceEngine::Precision::UNSPECIFIED) {
         inputPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(inPrc);
       }
       auto constInput1 = std::make_shared<ngraph::opset5::Constant>(

--- a/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
+++ b/inference-engine/tests/functional/shared_test_classes/src/single_layer/roi_pooling.cpp
@@ -91,7 +91,7 @@ namespace LayerTestsDefinitions {
         auto paramOuts = ngraph::helpers::convert2OutputVector(
                 ngraph::helpers::castOps2Nodes<ngraph::op::Parameter>(params));
         size_t size = 1;
-        for (auto dim : coordsShape){
+        for (auto dim : coordsShape) {
             size *= dim;
         }
         std::vector<float> coords(size);


### PR DESCRIPTION
Unlinted whitespace is causing build failures when building directly in the OV repo; this should fix that.