### PR TITLE
use stable sort to sort values and indices in topk

### DIFF
--- a/ngraph/core/reference/include/ngraph/runtime/reference/topk.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/topk.hpp
@@ -135,9 +135,11 @@ namespace ngraph
                         break;
                     case op::v1::TopK::SortType::SORT_VALUES:
                         if (compute_max)
-                            std::sort(workspace.begin(), workspace.begin() + k, compare_max<T, U>);
+                            std::stable_sort(
+                                workspace.begin(), workspace.begin() + k, compare_max<T, U>);
                         else
-                            std::sort(workspace.begin(), workspace.begin() + k, compare_min<T, U>);
+                            std::stable_sort(
+                                workspace.begin(), workspace.begin() + k, compare_min<T, U>);
                     }
                     for (size_t j = 0; j < k; j++)
                     {
@@ -148,8 +150,8 @@ namespace ngraph
                     }
                 }
             }
-        }
-    }
-}
+        } // namespace reference
+    }     // namespace runtime
+} // namespace ngraph
 
 NGRAPH_SUPPRESS_DEPRECATED_END


### PR DESCRIPTION
In the reference implementation of `TopK` `std::sort`(not `std::stable_sort`) is used, which does not guarantee to be stable. This is OK when sorting the `values` but when obtaining `indices` based on `values`, the `indices` of two equivalent `values` could be re-ordered. In my local env (OS & compiler) `std::sort` is stable and the TopK tests pass, but I suspect the tests may fail on some other OS/compilers due to possible unstable `std::sort` in ref implementation. 

This PR changes `std::sort` to `std::stable_sort` in reference implementations so that we can  make sure both ref implementation and our implementation of TopK are using stable sort/argsort. Please advice.