### PR TITLE
use stable_sort in DetectionOutput reference implementation

### DIFF
--- a/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
+++ b/ngraph/core/reference/include/ngraph/runtime/reference/detection_output.hpp
@@ -503,9 +503,9 @@ namespace ngraph
                             scoreIndexPairs.push_back(std::make_pair(conf, std::make_pair(id, p)));
                         }
                     }
-                    std::sort(scoreIndexPairs.begin(),
-                              scoreIndexPairs.end(),
-                              SortScorePairDescend<std::pair<int, int>>);
+                    std::stable_sort(scoreIndexPairs.begin(),
+                                     scoreIndexPairs.end(),
+                                     SortScorePairDescend<std::pair<int, int>>);
 
                     if (attrs.top_k != -1)
                         if (scoreIndexPairs.size() > attrs.top_k)
@@ -649,9 +649,9 @@ namespace ngraph
                                         std::make_pair(scores[idx], std::make_pair(label, idx)));
                                 }
                             }
-                            std::sort(scoreIndexPairs.begin(),
-                                      scoreIndexPairs.end(),
-                                      SortScorePairDescend<std::pair<int, int>>);
+                            std::stable_sort(scoreIndexPairs.begin(),
+                                             scoreIndexPairs.end(),
+                                             SortScorePairDescend<std::pair<int, int>>);
                             scoreIndexPairs.resize(attrs.keep_top_k[0]);
                             std::map<int, std::vector<int>> newIndices;
                             for (int j = 0; j < scoreIndexPairs.size(); ++j)


### PR DESCRIPTION
This change is very similar to #139. In short, `std::sort` is used and it does not guarantee to be stable. Changed to `std::stable_sort` instead.

Note: The `std::sort` at line 506 is inside of function `mxNetNms` and it's not yet implemented in https://github.com/plaidml/plaidml/pull/1741. Just change it along with the other `std::sort` in advance.